### PR TITLE
CCD-2131: Address CVE-2021-42340

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -231,7 +231,7 @@ dependencyManagement {
       entry 'json-path'
       entry 'xml-path'
     }
-    dependencySet(group: 'org.apache.tomcat.embed', version: '9.0.43') {
+    dependencySet(group: 'org.apache.tomcat.embed', version: '9.0.54') {
       entry 'tomcat-embed-core'
       entry 'tomcat-embed-el'
       entry 'tomcat-embed-websocket'

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -21,4 +21,8 @@
     <cve>CVE-2021-33037</cve>
     <cve>CVE-2021-41079</cve>
   </suppress>
+  <suppress until="2021-11-25">
+    <notes>Suppress CVE affecting spring-core temporarily until it can be addressed</notes>
+    <cve>CVE-2021-22096</cve>
+  </suppress>
 </suppressions>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -20,6 +20,5 @@
     <cve>CVE-2021-30640</cve>
     <cve>CVE-2021-33037</cve>
     <cve>CVE-2021-41079</cve>
-    <cve>CVE-2021-42340</cve>
   </suppress>
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###
CCD-2131 (https://tools.hmcts.net/jira/browse/CCD-2131)

### Change description ###
- Updated dependencyManagement section of build.gradle. Set version of org.apache.tomcat.embed group to 9.0.54 to resolve CVE-2021-42340.
- Removed suppression of CVE-2021-42340 from suppressions.xml


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
