### PR TITLE
CCD-2137: Address CVE-2021-22096

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -202,6 +202,7 @@ def versions = [
   testcontainers  : '1.15.2'
 ]
 
+ext['spring-framework.version'] = '5.3.12'
 
 // before committing a change, make sure task still works
 dependencyUpdates {

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -21,8 +21,4 @@
     <cve>CVE-2021-33037</cve>
     <cve>CVE-2021-41079</cve>
   </suppress>
-  <suppress until="2021-11-25">
-    <notes>Suppress CVE affecting spring-core temporarily until it can be addressed</notes>
-    <cve>CVE-2021-22096</cve>
-  </suppress>
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###
CCD-2137 (https://tools.hmcts.net/jira/browse/CCD-2137)


### Change description ###
- Updated build.gradle.  Added override of spring-framework.version property with value set to 5.3.12 to address CVE-2021-22096.
- Removed temporary suppression of CVE-2021-22096 from suppressions.xml


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
