### PR TITLE
CCD-2177: Review CVE suppressions

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -16,14 +16,7 @@
     <cve>CVE-2020-7712</cve>
   </suppress>
   <suppress until="2021-11-25">
-    <notes><![CDATA[Temporary suppressions pending investigation]]></notes>
-    <cve>CVE-2021-30640</cve>
-    <cve>CVE-2021-33037</cve>
-    <cve>CVE-2021-41079</cve>
-  </suppress>
-  <suppress until="2021-11-25">
-    <notes>Suppress CVE affecting spring-core temporarily until it can be addressed</notes>
-    <cve>CVE-2021-22096</cve>
+    <notes>Suppress CVEs affecting netty temporarily until they can be addressed</notes>
     <cve>CVE-2021-37136</cve>
     <cve>CVE-2021-37137</cve>
   </suppress>


### PR DESCRIPTION
### JIRA link (if applicable) ###
CCD-2177 (https://tools.hmcts.net/jira/browse/CCD-2177)


### Change description ###
- Removed temporary suppression of CVE-2021-30640, CVE-2021-33037 and CVE-2021-41079 from suppressions.xml.  These relate to vulnerabilities in earlier versions of Tomcat and recommended fix was to update to later version of Tomcat.  The update made to the version of Tomcat in Pull Request 13 (https://github.com/hmcts/hmc-cft-hearing-service/pull/13) for CCD-2131 changed it to a version that incorporated fixes for these CVEs so they no longer need to be suppressed.
- Removed temporary suppression of CVE-2021-22096.  This was fixed in Pull Request 14 (https://github.com/hmcts/hmc-cft-hearing-service/pull/14) for CCD-2137 which also removed the suppression.  Suppression seems to have been re-added by merge of changes from another branch.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
