### PR TITLE
CCD-2178: Address CVE-2021-37136 and CVE-2021-37137

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -200,7 +200,8 @@ def versions = [
   springBoot      : springBoot.class.package.implementationVersion,
   springCloud     : '2020.0.1',
   springfoxSwagger: '3.0.0',
-  testcontainers  : '1.15.2'
+  testcontainers  : '1.15.2',
+  netty           : '4.1.68.Final'
 ]
 
 ext['spring-framework.version'] = '5.3.12'
@@ -294,6 +295,24 @@ dependencies {
 
   implementation group: 'com.azure', name: 'azure-messaging-servicebus', version: '7.0.2'
   implementation group: 'com.azure', name: 'azure-core', version: '1.13.0'
+
+  // Explicitly set versions of io.netty components to resolve CVE-2021-37136 and CVE-2021-37137
+  implementation group: 'io.netty', name: 'netty-buffer', version: versions.netty
+  implementation group: 'io.netty', name: 'netty-codec', version: versions.netty
+  implementation group: 'io.netty', name: 'netty-codec-dns', version: versions.netty
+  implementation group: 'io.netty', name: 'netty-codec-http', version: versions.netty
+  implementation group: 'io.netty', name: 'netty-codec-http2', version: versions.netty
+  implementation group: 'io.netty', name: 'netty-codec-socks', version: versions.netty
+  implementation group: 'io.netty', name: 'netty-common', version: versions.netty
+  implementation group: 'io.netty', name: 'netty-handler', version: versions.netty
+  implementation group: 'io.netty', name: 'netty-handler-proxy', version: versions.netty
+  implementation group: 'io.netty', name: 'netty-resolver', version: versions.netty
+  implementation group: 'io.netty', name: 'netty-resolver-dns', version: versions.netty
+  implementation group: 'io.netty', name: 'netty-resolver-dns-native-macos', version: versions.netty
+  implementation group: 'io.netty', name: 'netty-transport', version: versions.netty
+  implementation group: 'io.netty', name: 'netty-transport-native-epoll', version: versions.netty
+  implementation group: 'io.netty', name: 'netty-transport-native-kqueue', version: versions.netty
+  implementation group: 'io.netty', name: 'netty-transport-native-unix-common', version: versions.netty
 
   testImplementation libraries.junit5
   testImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-test', {

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -15,9 +15,4 @@
     <cve>CVE-2020-10663</cve>
     <cve>CVE-2020-7712</cve>
   </suppress>
-  <suppress until="2021-11-25">
-    <notes>Suppress CVEs affecting netty temporarily until they can be addressed</notes>
-    <cve>CVE-2021-37136</cve>
-    <cve>CVE-2021-37137</cve>
-  </suppress>
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###
CCD-2178 (https://tools.hmcts.net/jira/browse/CCD-2178)


### Change description ###
- Updated build.gradle. Added netty property to versions object and netty entries to dependencies section to explicitly specify version of netty components. This resolves CVE-2021-37136 and CVE-2021-37137.
- Removed temporary suppression of CVE-2021-37136 and CVE-2021-37137 from suppressions.xml


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
