### PR TITLE
CCD-2316: Review CVE suppressions in suppressions.xml

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -1,5 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+  <suppress>
+    <notes>
+      Declared as False positive on library com.nimbusds:lang-tag #3594
+      https://github.com/jeremylong/DependencyCheck/issues/3594
+      Fixed in version 6.3.0 of DependencyCheck.
+      CVE-2020-23171
+    </notes>
+    <packageUrl regex="true">^pkg:maven/com\.nimbusds/lang\-tag@.*$</packageUrl>
+    <cpe>cpe:/a:nim-lang:nim-lang</cpe>
+    <cve>CVE-2020-23171</cve>
+  </suppress>
   <suppress until="2030-01-01">
     <notes><![CDATA[
      Suppressing as it's a false positive (see: https://pivotal.io/security/cve-2018-1258)
@@ -17,9 +28,6 @@
   </suppress>
   <suppress until="2021-12-25">
     <notes><![CDATA[Temporary suppressions pending investigation]]></notes>
-    <cve>CVE-2021-30640</cve>
-    <cve>CVE-2021-33037</cve>
-    <cve>CVE-2021-41079</cve>
     <cve>CVE-2021-29425</cve>
     <cve>CVE-2021-27568</cve>
     <cve>CVE-2021-28170</cve>
@@ -29,16 +37,7 @@
     <cve>CVE-2021-28169</cve>
     <cve>CVE-2021-34428</cve>
     <cve>CVE-2021-34429</cve>
-    <cve>CVE-2020-23171</cve>
-    <cve>CVE-2021-22096</cve>
     <cve>CVE-2021-22118</cve>
     <cve>CVE-2021-22119</cve>
-    <cve>CVE-2021-42340</cve>
-  </suppress>
-  <suppress until="2021-12-25">
-    <notes>Suppress CVEs affecting netty temporarily until they can be addressed</notes>
-    <cve>CVE-2021-22096</cve>
-    <cve>CVE-2021-37136</cve>
-    <cve>CVE-2021-37137</cve>
   </suppress>
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###
CCD-2316 (https://tools.hmcts.net/jira/browse/CCD-2316)


### Change description ###
- Moved entry for CVE-2020-23171 to a section where it is declared as a false positive.  This seems to have been resolved in version 6.3.0 of DependencyCheck and should be able to be removed if that version is used.
- Removed entries for CVE-2021-30640, CVE-2021-33037, CVE-2021-41079 and CVE-2021-42340.  These all relate to vulnerabilities in tomcat.  The change made in CCD-2131 to address CVE-2021-42340 (https://github.com/hmcts/hmc-cft-hearing-service/pull/13) updated tomcat to a version that addresses the others as well.
- Removed both entries for CVE-2021-22096 (one was a duplicate).  This was addressed in CCD-2137 (https://github.com/hmcts/hmc-cft-hearing-service/pull/14).
- Removed entries for CVE-2021-37136 and CVE-2021-37137.  These were addressed in CCD-2178 (https://github.com/hmcts/hmc-cft-hearing-service/pull/26).


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
