### PR TITLE
HMAN-57 DELETE linkedHearingGroup endpoint

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/hmc/constants/Constants.java
+++ b/src/main/java/uk/gov/hmcts/reform/hmc/constants/Constants.java
@@ -6,6 +6,7 @@ public final class Constants {
     }
 
     public static final String HEARING_STATUS = "HEARING_REQUESTED";
+    public static final String HEARING_STATUS_UPDATE_REQUESTED = "UPDATE_REQUESTED";
     public static final Integer VERSION_NUMBER = 1;
     public static final String EMAIL_TYPE = "email";
     public static final String PHONE_TYPE = "phone";

--- a/src/main/java/uk/gov/hmcts/reform/hmc/controllers/LinkedHearingGroupController.java
+++ b/src/main/java/uk/gov/hmcts/reform/hmc/controllers/LinkedHearingGroupController.java
@@ -1,0 +1,35 @@
+package uk.gov.hmcts.reform.hmc.controllers;
+
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+import uk.gov.hmcts.reform.hmc.service.LinkedHearingGroupService;
+
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
+@RestController
+public class LinkedHearingGroupController {
+
+    private LinkedHearingGroupService linkedHearingGroupService;
+
+    public LinkedHearingGroupController(LinkedHearingGroupService linkedHearingGroupService) {
+        this.linkedHearingGroupService = linkedHearingGroupService;
+    }
+
+    @DeleteMapping(path = "/linkedHearingGroup/{id}", consumes = APPLICATION_JSON_VALUE,
+        produces = APPLICATION_JSON_VALUE)
+    @ResponseStatus(HttpStatus.OK)
+    @ApiResponses(value = {
+        @ApiResponse(code = 200, message = "Hearing group deletion processed"),
+        @ApiResponse(code = 400, message = "Invalid hearing group details found"),
+        @ApiResponse(code = 404, message = "Hearing Group id not found"),
+        @ApiResponse(code = 500, message = "Error occurred on the server")
+    })
+    public void deleteHearingGroup(@PathVariable("id") Long hearingGroupId) {
+        linkedHearingGroupService.deleteLinkedHearingGroup(hearingGroupId);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/hmc/data/HearingEntity.java
+++ b/src/main/java/uk/gov/hmcts/reform/hmc/data/HearingEntity.java
@@ -10,6 +10,7 @@ import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
 import javax.persistence.OneToMany;
 import javax.persistence.OneToOne;
 import javax.persistence.PrimaryKeyJoinColumn;
@@ -38,4 +39,14 @@ public class HearingEntity {
 
     @OneToMany(mappedBy = "hearing", fetch = FetchType.EAGER)
     private List<HearingResponseEntity> hearingResponses;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "linked_group_id")
+    private LinkedGroupDetailsEntity linkedGroupDetails;
+
+    @Column(name = "linked_order")
+    private Long linkedOrder;
+
+    @Column(name = "is_linked_flag")
+    private Boolean isLinkedFlag;
 }

--- a/src/main/java/uk/gov/hmcts/reform/hmc/data/LinkedGroupDetailsEntity.java
+++ b/src/main/java/uk/gov/hmcts/reform/hmc/data/LinkedGroupDetailsEntity.java
@@ -16,8 +16,7 @@ import javax.persistence.Table;
 @Table(name = "linked_group_details")
 @Entity
 @Data
-
-public class LinkedGroupDetails {
+public class LinkedGroupDetailsEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY,

--- a/src/main/java/uk/gov/hmcts/reform/hmc/data/LinkedHearingDetailsEntity.java
+++ b/src/main/java/uk/gov/hmcts/reform/hmc/data/LinkedHearingDetailsEntity.java
@@ -15,7 +15,7 @@ import javax.persistence.Table;
 @Table(name = "linked_hearing_details")
 @Entity
 @Data
-public class LinkedHearingDetails {
+public class LinkedHearingDetailsEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY,
@@ -25,7 +25,7 @@ public class LinkedHearingDetails {
 
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "linked_group_id")
-    private LinkedGroupDetails linkedGroup;
+    private LinkedGroupDetailsEntity linkedGroup;
 
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "hearing_id")

--- a/src/main/java/uk/gov/hmcts/reform/hmc/exceptions/LinkedHearingGroupNotFoundException.java
+++ b/src/main/java/uk/gov/hmcts/reform/hmc/exceptions/LinkedHearingGroupNotFoundException.java
@@ -1,0 +1,12 @@
+package uk.gov.hmcts.reform.hmc.exceptions;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(value = HttpStatus.NOT_FOUND)
+public class LinkedHearingGroupNotFoundException extends RuntimeException {
+
+    public LinkedHearingGroupNotFoundException(Long hearingId, String errorMessage) {
+        super(String.format(errorMessage, hearingId));
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/hmc/exceptions/ValidationError.java
+++ b/src/main/java/uk/gov/hmcts/reform/hmc/exceptions/ValidationError.java
@@ -133,6 +133,12 @@ public final class ValidationError {
     public static final String PARTY_ROLE_EMPTY = "Party role must be present";
 
     public static final String HEARING_ID_NOT_FOUND = "No hearing found for reference: %s";
+    public static final String HEARING_GROUP_ID_NOT_FOUND = "No hearing group found for reference: %s";
+    public static final String INVALID_DELETE_HEARING_GROUP_STATUS = "007 group is in a %s state";
+    public static final String INVALID_DELETE_HEARING_GROUP_HEARING_STATUS = "008 Invalid state for unlinking hearing"
+        + " request %s";
+    public static final String INVALID_DELETE_HEARING_GROUP_DAY_IN_THE_PAST = "004 Invalid start date in the past"
+        + " for unlinking hearing request %s";
     public static final String PARTIES_NOTIFIED_ID_NOT_FOUND = "001 No such id: %s";
     public static final String PARTIES_NOTIFIED_RESPONSE_VERSION_MISMATCH = "002 No such response version";
     public static final String PARTIES_NOTIFIED_ALREADY_SET = "003 Already set";

--- a/src/main/java/uk/gov/hmcts/reform/hmc/repository/LinkedHearingDetailsRepository.java
+++ b/src/main/java/uk/gov/hmcts/reform/hmc/repository/LinkedHearingDetailsRepository.java
@@ -1,0 +1,22 @@
+package uk.gov.hmcts.reform.hmc.repository;
+
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import uk.gov.hmcts.reform.hmc.data.LinkedHearingDetailsEntity;
+
+import java.util.List;
+
+@Transactional(propagation = Propagation.REQUIRES_NEW)
+@Repository
+public interface LinkedHearingDetailsRepository extends CrudRepository<LinkedHearingDetailsEntity, Long> {
+
+    @Query("from LinkedHearingDetailsEntity lhde where lhde.linkedGroup.linkedGroupId = :linkedGroupId")
+    List<LinkedHearingDetailsEntity> getLinkedHearingDetails(Long linkedGroupId);
+
+    default void deleteHearingGroup(Long hearingGroupId) {
+        // TODO: implement
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/hmc/repository/LinkedHearingDetailsRepository.java
+++ b/src/main/java/uk/gov/hmcts/reform/hmc/repository/LinkedHearingDetailsRepository.java
@@ -17,6 +17,6 @@ public interface LinkedHearingDetailsRepository extends CrudRepository<LinkedHea
     List<LinkedHearingDetailsEntity> getLinkedHearingDetails(Long linkedGroupId);
 
     default void deleteHearingGroup(Long hearingGroupId) {
-        // TODO: implement
+        // TODO: implement DB query - https://tools.hmcts.net/jira/browse/HMAN-96
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/hmc/service/LinkedHearingGroupService.java
+++ b/src/main/java/uk/gov/hmcts/reform/hmc/service/LinkedHearingGroupService.java
@@ -110,5 +110,6 @@ public class LinkedHearingGroupService {
 
     private void deleteFromLinkedGroupDetails(Long hearingGroupId) {
         linkedHearingDetailsRepository.deleteHearingGroup(hearingGroupId);
+        // TODO: call ListAssist - https://tools.hmcts.net/jira/browse/HMAN-97
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/hmc/service/LinkedHearingGroupService.java
+++ b/src/main/java/uk/gov/hmcts/reform/hmc/service/LinkedHearingGroupService.java
@@ -1,0 +1,114 @@
+package uk.gov.hmcts.reform.hmc.service;
+
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.hmc.data.HearingEntity;
+import uk.gov.hmcts.reform.hmc.data.HearingResponseEntity;
+import uk.gov.hmcts.reform.hmc.data.LinkedHearingDetailsEntity;
+import uk.gov.hmcts.reform.hmc.domain.model.enums.DeleteHearingStatus;
+import uk.gov.hmcts.reform.hmc.exceptions.BadRequestException;
+import uk.gov.hmcts.reform.hmc.exceptions.LinkedHearingGroupNotFoundException;
+import uk.gov.hmcts.reform.hmc.repository.LinkedHearingDetailsRepository;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static java.lang.String.format;
+import static java.util.stream.Collectors.groupingBy;
+import static uk.gov.hmcts.reform.hmc.exceptions.ValidationError.HEARING_GROUP_ID_NOT_FOUND;
+import static uk.gov.hmcts.reform.hmc.exceptions.ValidationError.INVALID_DELETE_HEARING_GROUP_DAY_IN_THE_PAST;
+import static uk.gov.hmcts.reform.hmc.exceptions.ValidationError.INVALID_DELETE_HEARING_GROUP_HEARING_STATUS;
+import static uk.gov.hmcts.reform.hmc.exceptions.ValidationError.INVALID_DELETE_HEARING_GROUP_STATUS;
+
+@Service
+public class LinkedHearingGroupService {
+    private static final List<String> invalidDeleteGroupStatuses = Arrays.asList("PENDING", "ERROR");
+
+    private final LinkedHearingDetailsRepository linkedHearingDetailsRepository;
+
+    public LinkedHearingGroupService(LinkedHearingDetailsRepository linkedHearingDetailsRepository) {
+        this.linkedHearingDetailsRepository = linkedHearingDetailsRepository;
+    }
+
+    public void deleteLinkedHearingGroup(Long hearingGroupId) {
+
+        List<LinkedHearingDetailsEntity> linkedHearingDetails = validateHearingGroupPresent(hearingGroupId);
+        validateHearingGroupStatus(linkedHearingDetails);
+        validateUnlinkingHearingsStatus(linkedHearingDetails);
+        validateUnlinkingHearingsWillNotHaveStartDateInThePast(linkedHearingDetails);
+
+        deleteFromLinkedGroupDetails(hearingGroupId);
+    }
+
+    private void validateUnlinkingHearingsWillNotHaveStartDateInThePast(
+        List<LinkedHearingDetailsEntity> linkedHearingDetails) {
+
+        linkedHearingDetails.stream()
+            .map(LinkedHearingDetailsEntity::getHearing)
+            .filter(h -> h.getHearingResponses().size() > 0)
+            .forEach(hearing -> {
+                List<HearingResponseEntity> latestVersionHearingResponses = getLatestVersionHearingResponses(hearing);
+
+                Optional<HearingResponseEntity> mostRecentLatestVersionHearingResponse = latestVersionHearingResponses
+                    .stream().max(Comparator.comparing(HearingResponseEntity::getRequestTimeStamp));
+
+                boolean hasHearingDateInThePast = mostRecentLatestVersionHearingResponse.isPresent()
+                    && mostRecentLatestVersionHearingResponse.get()
+                    .getHearingDayDetails().stream()
+                    .anyMatch(dayTime -> dayTime.getStartDateTime().isBefore(LocalDateTime.now()));
+
+                if (hasHearingDateInThePast) {
+                    throw new BadRequestException(format(
+                        INVALID_DELETE_HEARING_GROUP_DAY_IN_THE_PAST,
+                        hearing.getId()
+                    ));
+                }
+            });
+    }
+
+    private List<HearingResponseEntity> getLatestVersionHearingResponses(HearingEntity hearing) {
+        Optional<Map.Entry<String, List<HearingResponseEntity>>> max = hearing.getHearingResponses().stream()
+            .collect(groupingBy(HearingResponseEntity::getRequestVersion))
+            .entrySet()
+            .stream()
+            .max(Map.Entry.comparingByKey());
+
+        return max.isPresent() ? max.get().getValue() : List.of();
+    }
+
+    private void validateHearingGroupStatus(List<LinkedHearingDetailsEntity> linkedHearingDetails) {
+        String groupStatus = linkedHearingDetails.get(0).getLinkedGroup().getStatus();
+        if (invalidDeleteGroupStatuses.stream().anyMatch(e -> e.equals(groupStatus))) {
+            throw new BadRequestException(format(INVALID_DELETE_HEARING_GROUP_STATUS, groupStatus));
+        }
+    }
+
+    private List<LinkedHearingDetailsEntity> validateHearingGroupPresent(Long hearingGroupId) {
+        List<LinkedHearingDetailsEntity> linkedHearingDetails =
+            linkedHearingDetailsRepository.getLinkedHearingDetails(hearingGroupId);
+        if (linkedHearingDetails.isEmpty()) {
+            throw new LinkedHearingGroupNotFoundException(hearingGroupId, HEARING_GROUP_ID_NOT_FOUND);
+        }
+        return linkedHearingDetails;
+    }
+
+    private void validateUnlinkingHearingsStatus(List<LinkedHearingDetailsEntity> linkedHearingDetails) {
+        List<HearingEntity> unlinkInvalidStatusHearings = linkedHearingDetails.stream()
+            .map(LinkedHearingDetailsEntity::getHearing)
+            .filter(h -> !DeleteHearingStatus.isValid(h.getStatus()))
+            .collect(Collectors.toList());
+
+        if (!unlinkInvalidStatusHearings.isEmpty()) {
+            throw new BadRequestException(
+                format(INVALID_DELETE_HEARING_GROUP_HEARING_STATUS, unlinkInvalidStatusHearings.get(0).getId()));
+        }
+    }
+
+    private void deleteFromLinkedGroupDetails(Long hearingGroupId) {
+        linkedHearingDetailsRepository.deleteHearingGroup(hearingGroupId);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/hmc/service/LinkedHearingGroupServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/hmc/service/LinkedHearingGroupServiceTest.java
@@ -1,0 +1,345 @@
+package uk.gov.hmcts.reform.hmc.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.reform.hmc.data.HearingDayDetailsEntity;
+import uk.gov.hmcts.reform.hmc.data.HearingEntity;
+import uk.gov.hmcts.reform.hmc.data.HearingResponseEntity;
+import uk.gov.hmcts.reform.hmc.data.LinkedGroupDetailsEntity;
+import uk.gov.hmcts.reform.hmc.data.LinkedHearingDetailsEntity;
+import uk.gov.hmcts.reform.hmc.exceptions.BadRequestException;
+import uk.gov.hmcts.reform.hmc.exceptions.LinkedHearingGroupNotFoundException;
+import uk.gov.hmcts.reform.hmc.repository.LinkedHearingDetailsRepository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static uk.gov.hmcts.reform.hmc.constants.Constants.HEARING_STATUS;
+import static uk.gov.hmcts.reform.hmc.constants.Constants.HEARING_STATUS_UPDATE_REQUESTED;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("checkstyle:AbbreviationAsWordInName")
+class LinkedHearingGroupServiceTest {
+
+    public static final String FOR_DELETE_INVALID_HEARING_STATUS = "HEARING_STATUS_INVALID";
+    public static final long HEARING_GROUP_ID = 567L;
+    public static final long HEARING_ID1 = 1234L;
+    public static final long HEARING_ID2 = 1235L;
+    public static final LocalDateTime START_DATE_TIME_IN_THE_FUTURE =
+        LocalDateTime.of(2500, 10, 1, 1, 1);
+    public static final LocalDateTime START_DATE_TIME_IN_THE_PAST =
+        LocalDateTime.of(2000, 10, 1, 1, 1);
+    public static final LocalDateTime HEARING_RESPONSE_DATE_TIME = LocalDateTime.now();
+
+    @Mock
+    LinkedHearingDetailsRepository linkedHearingDetailsRepository;
+
+    @InjectMocks
+    private LinkedHearingGroupService service;
+
+    @BeforeEach
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+        service = new LinkedHearingGroupService(linkedHearingDetailsRepository);
+    }
+
+    @Nested
+    @DisplayName("deleteHearingGroup")
+    class DeleteHearingGroup {
+
+        @Test
+        public void shouldDeleteHearingGroupDetails() {
+
+            HearingEntity hearing1 = new HearingEntity();
+            hearing1.setId(HEARING_ID1);
+            hearing1.setStatus(HEARING_STATUS);
+            hearing1.setIsLinkedFlag(true);
+            hearing1.setHearingResponses(List.of(
+                createHearingResponseEntityWithHearingDays("1", HEARING_RESPONSE_DATE_TIME,
+                                                           List.of(START_DATE_TIME_IN_THE_FUTURE)
+                ),
+                createHearingResponseEntityWithHearingDays("1", HEARING_RESPONSE_DATE_TIME,
+                                                           List.of(START_DATE_TIME_IN_THE_FUTURE,
+                                                                   START_DATE_TIME_IN_THE_FUTURE)
+                )));
+
+            HearingEntity hearing2 = new HearingEntity();
+            hearing2.setId(HEARING_ID2);
+            hearing2.setStatus(HEARING_STATUS);
+            hearing2.setIsLinkedFlag(true);
+            hearing2.setHearingResponses(List.of(
+                createHearingResponseEntityWithHearingDays("1", HEARING_RESPONSE_DATE_TIME,
+                                                           List.of(START_DATE_TIME_IN_THE_FUTURE)
+                )));
+
+            LinkedGroupDetailsEntity groupDetails = createGroupDetailsEntity(HEARING_GROUP_ID, "ACTIVE");
+            LinkedHearingDetailsEntity hearingDetails1 = createHearingDetailsEntity(groupDetails, hearing1);
+            LinkedHearingDetailsEntity hearingDetails2 = createHearingDetailsEntity(groupDetails, hearing2);
+
+            given(linkedHearingDetailsRepository.getLinkedHearingDetails(HEARING_GROUP_ID))
+                .willReturn(List.of(hearingDetails1, hearingDetails2));
+
+            service.deleteLinkedHearingGroup(HEARING_GROUP_ID);
+            verify(linkedHearingDetailsRepository, times(1)).getLinkedHearingDetails(HEARING_GROUP_ID);
+            verify(linkedHearingDetailsRepository, times(1)).deleteHearingGroup(HEARING_GROUP_ID);
+        }
+
+        @Test
+        public void shouldReturn404ErrorWhenNonExistentHearingGroup() {
+            given(linkedHearingDetailsRepository.getLinkedHearingDetails(HEARING_GROUP_ID)).willReturn(List.of());
+
+            Exception exception = assertThrows(LinkedHearingGroupNotFoundException.class, () ->
+                service.deleteLinkedHearingGroup(HEARING_GROUP_ID));
+            assertEquals("No hearing group found for reference: " + HEARING_GROUP_ID, exception.getMessage());
+            verify(linkedHearingDetailsRepository, times(1)).getLinkedHearingDetails(HEARING_GROUP_ID);
+            verifyNoMoreInteractions(linkedHearingDetailsRepository);
+        }
+
+        @Test
+        public void shouldReturn400ErrorWhenGroupDetailsHasStatusPENDING() {
+            LinkedHearingDetailsEntity hearingDetails = createHearingDetailsEntity(
+                createGroupDetailsEntity(HEARING_GROUP_ID, "PENDING"));
+
+            given(linkedHearingDetailsRepository.getLinkedHearingDetails(HEARING_GROUP_ID))
+                .willReturn(List.of(hearingDetails));
+
+            Exception exception = assertThrows(BadRequestException.class, () ->
+                service.deleteLinkedHearingGroup(HEARING_GROUP_ID));
+            assertEquals("007 group is in a PENDING state", exception.getMessage());
+            verify(linkedHearingDetailsRepository, times(1)).getLinkedHearingDetails(HEARING_GROUP_ID);
+            verifyNoMoreInteractions(linkedHearingDetailsRepository);
+        }
+
+        @Test
+        public void shouldReturn400ErrorWhenGroupDetailsHasStatusERROR() {
+            LinkedHearingDetailsEntity hearingDetails = createHearingDetailsEntity(
+                createGroupDetailsEntity(HEARING_GROUP_ID, "ERROR"));
+
+            given(linkedHearingDetailsRepository.getLinkedHearingDetails(HEARING_GROUP_ID))
+                .willReturn(List.of(hearingDetails));
+
+            Exception exception = assertThrows(BadRequestException.class, () ->
+                service.deleteLinkedHearingGroup(HEARING_GROUP_ID));
+            assertEquals("007 group is in a ERROR state", exception.getMessage());
+            verify(linkedHearingDetailsRepository, times(1)).getLinkedHearingDetails(HEARING_GROUP_ID);
+            verifyNoMoreInteractions(linkedHearingDetailsRepository);
+        }
+
+        @Test
+        public void shouldReturn400ErrorWhenHearingStatusIsHEARING_REQUESTEDButPlannedHearingDateInThePast() {
+
+            HearingEntity hearing1 = new HearingEntity();
+            hearing1.setId(HEARING_ID1);
+            hearing1.setStatus(HEARING_STATUS);
+            hearing1.setIsLinkedFlag(true);
+            hearing1.setHearingResponses(List.of(
+                createHearingResponseEntityWithHearingDays("1", HEARING_RESPONSE_DATE_TIME,
+                                                           List.of(START_DATE_TIME_IN_THE_FUTURE)
+                ),
+                createHearingResponseEntityWithHearingDays("1", HEARING_RESPONSE_DATE_TIME,
+                                                           List.of(START_DATE_TIME_IN_THE_FUTURE,
+                                                                   START_DATE_TIME_IN_THE_FUTURE)
+                )));
+
+            HearingEntity hearing2 = new HearingEntity();
+            hearing2.setId(HEARING_ID2);
+            hearing2.setStatus(HEARING_STATUS);
+            hearing2.setIsLinkedFlag(true);
+            hearing2.setHearingResponses(List.of(
+                createHearingResponseEntityWithHearingDays("1", HEARING_RESPONSE_DATE_TIME,
+                                                           List.of(START_DATE_TIME_IN_THE_FUTURE,
+                                                                   START_DATE_TIME_IN_THE_PAST)
+                ),
+                createHearingResponseEntityWithHearingDays("1", HEARING_RESPONSE_DATE_TIME,
+                                                           List.of(START_DATE_TIME_IN_THE_FUTURE)
+                )));
+
+            LinkedGroupDetailsEntity groupDetails = createGroupDetailsEntity(HEARING_GROUP_ID, "ACTIVE");
+            LinkedHearingDetailsEntity hearingDetails1 = createHearingDetailsEntity(groupDetails, hearing1);
+            LinkedHearingDetailsEntity hearingDetails2 = createHearingDetailsEntity(groupDetails, hearing2);
+
+            given(linkedHearingDetailsRepository.getLinkedHearingDetails(HEARING_GROUP_ID))
+                .willReturn(List.of(hearingDetails1, hearingDetails2));
+
+            Exception exception = assertThrows(BadRequestException.class, () ->
+                service.deleteLinkedHearingGroup(HEARING_GROUP_ID));
+            assertEquals("004 Invalid start date in the past for unlinking hearing request " + HEARING_ID2,
+                         exception.getMessage());
+            verify(linkedHearingDetailsRepository, times(1)).getLinkedHearingDetails(HEARING_GROUP_ID);
+            verifyNoMoreInteractions(linkedHearingDetailsRepository);
+        }
+
+        @Test
+        public void shouldReturn400ErrorWhenHearingStatusIsUPDATE_REQUESTEDButPlannedHearingDateInThePast() {
+
+            HearingEntity hearing1 = new HearingEntity();
+            hearing1.setId(HEARING_ID1);
+            hearing1.setStatus(HEARING_STATUS_UPDATE_REQUESTED);
+            hearing1.setIsLinkedFlag(true);
+            hearing1.setHearingResponses(List.of(
+                createHearingResponseEntityWithHearingDays("1", HEARING_RESPONSE_DATE_TIME,
+                                                           List.of(START_DATE_TIME_IN_THE_FUTURE,
+                                                                   START_DATE_TIME_IN_THE_PAST)
+                )));
+
+            LinkedGroupDetailsEntity groupDetails = createGroupDetailsEntity(HEARING_GROUP_ID, "ACTIVE");
+            LinkedHearingDetailsEntity hearingDetails1 = createHearingDetailsEntity(groupDetails, hearing1);
+
+            given(linkedHearingDetailsRepository.getLinkedHearingDetails(HEARING_GROUP_ID))
+                .willReturn(List.of(hearingDetails1));
+
+            Exception exception = assertThrows(BadRequestException.class, () ->
+                service.deleteLinkedHearingGroup(HEARING_GROUP_ID));
+            assertEquals("004 Invalid start date in the past for unlinking hearing request " + HEARING_ID1,
+                         exception.getMessage());
+            verify(linkedHearingDetailsRepository, times(1)).getLinkedHearingDetails(HEARING_GROUP_ID);
+            verifyNoMoreInteractions(linkedHearingDetailsRepository);
+        }
+
+        @Test
+        public void shouldReturn400ErrorWhenHearingStatusIsInvalidForUnlinking() {
+
+            HearingEntity hearing1 = new HearingEntity();
+            hearing1.setId(HEARING_ID1);
+            hearing1.setStatus(FOR_DELETE_INVALID_HEARING_STATUS);
+            hearing1.setIsLinkedFlag(true);
+            hearing1.setHearingResponses(List.of(
+                createHearingResponseEntityWithHearingDays("1", HEARING_RESPONSE_DATE_TIME,
+                                                           List.of(START_DATE_TIME_IN_THE_FUTURE)
+                )));
+
+            LinkedGroupDetailsEntity groupDetails = createGroupDetailsEntity(HEARING_GROUP_ID, "ACTIVE");
+            LinkedHearingDetailsEntity hearingDetails1 = createHearingDetailsEntity(groupDetails, hearing1);
+
+            given(linkedHearingDetailsRepository.getLinkedHearingDetails(HEARING_GROUP_ID))
+                .willReturn(List.of(hearingDetails1));
+
+            Exception exception = assertThrows(BadRequestException.class, () ->
+                service.deleteLinkedHearingGroup(HEARING_GROUP_ID));
+            assertEquals("008 Invalid state for unlinking hearing request " + HEARING_ID1,
+                         exception.getMessage());
+            verify(linkedHearingDetailsRepository, times(1)).getLinkedHearingDetails(HEARING_GROUP_ID);
+            verifyNoMoreInteractions(linkedHearingDetailsRepository);
+        }
+
+        @Test
+        public void shouldDeleteHearingGroupDetailsFilteringOutInvalidMultipleResponseHearingVersions() {
+
+            HearingEntity hearing1 = new HearingEntity();
+            hearing1.setId(HEARING_ID1);
+            hearing1.setStatus(HEARING_STATUS);
+            hearing1.setIsLinkedFlag(true);
+            hearing1.setHearingResponses(List.of(
+                createHearingResponseEntityWithHearingDays("2", HEARING_RESPONSE_DATE_TIME,
+                                                           List.of(START_DATE_TIME_IN_THE_FUTURE)
+                ),
+                createHearingResponseEntityWithHearingDays("1", HEARING_RESPONSE_DATE_TIME,
+                                                           // should not fail as will get filtered out
+                                                           List.of(START_DATE_TIME_IN_THE_PAST,
+                                                                   START_DATE_TIME_IN_THE_FUTURE)
+                )));
+
+            HearingEntity hearing2 = new HearingEntity();
+            hearing2.setId(HEARING_ID2);
+            hearing2.setStatus(HEARING_STATUS);
+            hearing2.setIsLinkedFlag(true);
+            hearing2.setHearingResponses(List.of(
+                createHearingResponseEntityWithHearingDays("1", HEARING_RESPONSE_DATE_TIME,
+                                                           List.of(START_DATE_TIME_IN_THE_FUTURE)
+                )));
+
+            LinkedGroupDetailsEntity groupDetails = createGroupDetailsEntity(HEARING_GROUP_ID, "ACTIVE");
+            LinkedHearingDetailsEntity hearingDetails1 = createHearingDetailsEntity(groupDetails, hearing1);
+            LinkedHearingDetailsEntity hearingDetails2 = createHearingDetailsEntity(groupDetails, hearing2);
+
+            given(linkedHearingDetailsRepository.getLinkedHearingDetails(HEARING_GROUP_ID))
+                .willReturn(List.of(hearingDetails1, hearingDetails2));
+
+            service.deleteLinkedHearingGroup(HEARING_GROUP_ID);
+
+            verify(linkedHearingDetailsRepository, times(1)).getLinkedHearingDetails(HEARING_GROUP_ID);
+            verify(linkedHearingDetailsRepository, times(1)).deleteHearingGroup(HEARING_GROUP_ID);
+        }
+
+        @Test
+        public void shouldDeleteHearingGroupDetailsFilteringOutHearingResponsesWithNonRecentTimestampForSameVersion() {
+
+            HearingEntity hearing1 = new HearingEntity();
+            hearing1.setId(HEARING_ID1);
+            hearing1.setStatus(HEARING_STATUS);
+            hearing1.setIsLinkedFlag(true);
+            hearing1.setHearingResponses(List.of(
+                createHearingResponseEntityWithHearingDays("1", HEARING_RESPONSE_DATE_TIME.minusDays(1),
+                                                           // should not fail as will get filtered out
+                                                           List.of(START_DATE_TIME_IN_THE_PAST)
+                ),
+                createHearingResponseEntityWithHearingDays("1", HEARING_RESPONSE_DATE_TIME,
+                                                           List.of(START_DATE_TIME_IN_THE_FUTURE)
+                )));
+
+            LinkedGroupDetailsEntity groupDetails = createGroupDetailsEntity(HEARING_GROUP_ID, "ACTIVE");
+            LinkedHearingDetailsEntity hearingDetails1 = createHearingDetailsEntity(groupDetails, hearing1);
+
+            given(linkedHearingDetailsRepository.getLinkedHearingDetails(HEARING_GROUP_ID))
+                .willReturn(List.of(hearingDetails1));
+
+            service.deleteLinkedHearingGroup(HEARING_GROUP_ID);
+
+            verify(linkedHearingDetailsRepository, times(1)).getLinkedHearingDetails(HEARING_GROUP_ID);
+            verify(linkedHearingDetailsRepository, times(1)).deleteHearingGroup(HEARING_GROUP_ID);
+        }
+
+        private HearingResponseEntity createHearingResponseEntityWithHearingDays(
+            String requestVersion,
+            LocalDateTime requestTimestamp,
+            List<LocalDateTime> hearingDaysStartDateTime) {
+
+            HearingResponseEntity hearingResponse = new HearingResponseEntity();
+            hearingResponse.setRequestVersion(requestVersion);
+            hearingResponse.setRequestTimeStamp(requestTimestamp);
+            hearingResponse.setHearingDayDetails(
+                hearingDaysStartDateTime.stream().map(this::createHearingDayDetails).collect(Collectors.toList())
+            );
+            return hearingResponse;
+        }
+
+        private HearingDayDetailsEntity createHearingDayDetails(LocalDateTime hearingDayStartDateTime) {
+            HearingDayDetailsEntity hearingDayDetails1 = new HearingDayDetailsEntity();
+            hearingDayDetails1.setStartDateTime(hearingDayStartDateTime);
+            return hearingDayDetails1;
+        }
+
+        private LinkedGroupDetailsEntity createGroupDetailsEntity(Long hearingGroupId, String groupStatus) {
+            LinkedGroupDetailsEntity groupDetails = new LinkedGroupDetailsEntity();
+            groupDetails.setLinkedGroupId(hearingGroupId);
+            groupDetails.setStatus(groupStatus);
+            return groupDetails;
+        }
+
+        private LinkedHearingDetailsEntity createHearingDetailsEntity(LinkedGroupDetailsEntity groupDetails) {
+            return createHearingDetailsEntity(groupDetails, null);
+        }
+
+        private LinkedHearingDetailsEntity createHearingDetailsEntity(LinkedGroupDetailsEntity groupDetails,
+                                                                      HearingEntity hearing) {
+            LinkedHearingDetailsEntity hearingDetails = new LinkedHearingDetailsEntity();
+            hearingDetails.setLinkedGroup(groupDetails);
+            hearingDetails.setHearing(hearing);
+            return hearingDetails;
+        }
+    }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/HMAN-57


### Change description ###
Establish the DELETE /linkedHearingGroup/{id} end-point for deleting the members of a group of linked hearing requests


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ X] No
```
