### PR TITLE
HMAN-150 - Map LA caseCourt field based on updated spec

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/hmc/helper/hmi/HmiCaseDetailsMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/hmc/helper/hmi/HmiCaseDetailsMapper.java
@@ -5,12 +5,15 @@ import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.hmc.model.CaseDetails;
 import uk.gov.hmcts.reform.hmc.model.hmi.CaseLinks;
 import uk.gov.hmcts.reform.hmc.model.hmi.HmiCaseDetails;
+import uk.gov.hmcts.reform.hmc.model.hmi.ListingLocation;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
 import static java.lang.Boolean.TRUE;
+import static uk.gov.hmcts.reform.hmc.constants.Constants.COURT;
+import static uk.gov.hmcts.reform.hmc.constants.Constants.EPIMS;
 import static uk.gov.hmcts.reform.hmc.constants.Constants.NOT_REQUIRED;
 import static uk.gov.hmcts.reform.hmc.constants.Constants.REQUIRED;
 
@@ -32,7 +35,11 @@ public class HmiCaseDetailsMapper {
                 .caseListingRequestId(hearingId.toString())
                 .caseJurisdiction(caseDetails.getHmctsServiceCode().substring(0, 2))
                 .caseTitle(caseDetails.getHmctsInternalCaseName())
-                .caseCourt(caseDetails.getCaseManagementLocationCode())
+                .caseCourt(ListingLocation.builder()
+                               .locationId(caseDetails.getCaseManagementLocationCode())
+                               .locationReferenceType(EPIMS)
+                               .locationType(COURT)
+                               .build())
                 .caseRegistered(caseDetails.getCaseSlaStartDate())
                 .caseInterpreterRequiredFlag(caseDetails.getCaseInterpreterRequiredFlag())
                 .caseRestrictedFlag(caseDetails.getCaseRestrictedFlag())

--- a/src/main/java/uk/gov/hmcts/reform/hmc/model/hmi/HmiCaseDetails.java
+++ b/src/main/java/uk/gov/hmcts/reform/hmc/model/hmi/HmiCaseDetails.java
@@ -26,7 +26,7 @@ public class HmiCaseDetails {
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T00:00:00Z'")
     private LocalDate caseRegistered;
 
-    private String caseCourt;
+    private ListingLocation caseCourt;
 
     private List<CaseClassification> caseClassifications;
 

--- a/src/test/java/uk/gov/hmcts/reform/hmc/helper/hmi/HmiCaseDetailsMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/hmc/helper/hmi/HmiCaseDetailsMapperTest.java
@@ -8,6 +8,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.reform.hmc.model.CaseDetails;
 import uk.gov.hmcts.reform.hmc.model.hmi.CaseClassification;
 import uk.gov.hmcts.reform.hmc.model.hmi.HmiCaseDetails;
+import uk.gov.hmcts.reform.hmc.model.hmi.ListingLocation;
 
 import java.time.LocalDate;
 import java.util.Arrays;
@@ -18,6 +19,8 @@ import static java.lang.Boolean.FALSE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.hmc.constants.Constants.COURT;
+import static uk.gov.hmcts.reform.hmc.constants.Constants.EPIMS;
 import static uk.gov.hmcts.reform.hmc.constants.Constants.NOT_REQUIRED;
 import static uk.gov.hmcts.reform.hmc.constants.Constants.REQUIRED;
 
@@ -63,7 +66,11 @@ class HmiCaseDetailsMapperTest {
             .caseListingRequestId(hearingId.toString())
             .caseJurisdiction("AB")
             .caseTitle(CASE_NAME)
-            .caseCourt(LOCATION_CODE)
+            .caseCourt(ListingLocation.builder()
+                           .locationId(LOCATION_CODE)
+                           .locationType(COURT)
+                           .locationReferenceType(EPIMS)
+                           .build())
             .caseRegistered(localDate)
             .caseInterpreterRequiredFlag(false)
             .caseRestrictedFlag(true)
@@ -104,7 +111,11 @@ class HmiCaseDetailsMapperTest {
             .caseListingRequestId(hearingId.toString())
             .caseJurisdiction("AB")
             .caseTitle(CASE_NAME)
-            .caseCourt(LOCATION_CODE)
+            .caseCourt(ListingLocation.builder()
+                           .locationId(LOCATION_CODE)
+                           .locationType(COURT)
+                           .locationReferenceType(EPIMS)
+                           .build())
             .caseRegistered(localDate)
             .caseInterpreterRequiredFlag(false)
             .caseRestrictedFlag(true)


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/HMAN-150


### Change description ###
Map LA `caseCourt` field with `locationId` of provided `caseManagementLocationCode`, and hardcoded `locationType` of value `Court` and `locationReferenceType` of value `EPIMS`.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
