### PR TITLE
HMAN-152 Remove the mandatory condition for cftOrganisationID for the hearing request payload

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/hmc/controllers/HearingManagementControllerIT.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/hmc/controllers/HearingManagementControllerIT.java
@@ -320,7 +320,7 @@ class HearingManagementControllerIT extends BaseTest {
         HearingRequest createHearingRequest = new HearingRequest();
         createHearingRequest.setHearingDetails(TestingUtil.hearingDetails());
         createHearingRequest.getHearingDetails().setPanelRequirements(TestingUtil.panelRequirements());
-        createHearingRequest.setCaseDetails(TestingUtil.caseDetails());
+        createHearingRequest.setCaseDetails(TestingUtil.getValidCaseDetails());
         createHearingRequest.setPartyDetails(TestingUtil.partyDetails());
         createHearingRequest.getPartyDetails().get(0).setIndividualDetails(TestingUtil.individualDetails());
         createHearingRequest.getPartyDetails().get(1).setOrganisationDetails(TestingUtil.organisationDetailsIdNull());

--- a/src/integrationTest/java/uk/gov/hmcts/reform/hmc/controllers/HearingManagementControllerIT.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/hmc/controllers/HearingManagementControllerIT.java
@@ -1138,46 +1138,6 @@ class HearingManagementControllerIT extends BaseTest {
     }
 
     @Test
-    @Sql(DELETE_HEARING_DATA_SCRIPT)
-    void shouldReturn201_WhenHearingRequestHasValidDataOrgIdNull() throws Exception {
-        HearingRequest hearingRequest = new HearingRequest();
-        hearingRequest.setHearingDetails(TestingUtil.hearingDetails());
-        hearingRequest.getHearingDetails().setPanelRequirements(TestingUtil.panelRequirements());
-        hearingRequest.setCaseDetails(TestingUtil.caseDetails());
-        hearingRequest.setPartyDetails(TestingUtil.partyDetails());
-        hearingRequest.getPartyDetails().get(0).setIndividualDetails(TestingUtil.individualDetails());
-        hearingRequest.getPartyDetails().get(1).setOrganisationDetails(TestingUtil.organisationDetailsIdNull());
-        hearingRequest.getHearingDetails().setListingComments("a".repeat(2000));
-        hearingRequest.getPartyDetails().get(0).getIndividualDetails().getRelatedParties()
-            .get(0).setRelatedPartyID("a".repeat(15));
-        hearingRequest.getPartyDetails().get(0).getIndividualDetails().getRelatedParties()
-            .get(0).setRelationshipType("a".repeat(10));
-        stubSuccessfullyValidateHearingObject(hearingRequest);
-        RoleAssignmentResource resource = new RoleAssignmentResource();
-        resource.setRoleName(ROLE_NAME);
-        resource.setRoleType(ROLE_TYPE);
-        RoleAssignmentAttributesResource attributesResource = new RoleAssignmentAttributesResource();
-        attributesResource.setCaseType(Optional.of(CASE_TYPE));
-        attributesResource.setJurisdiction(Optional.of(JURISDICTION));
-        resource.setAttributes(attributesResource);
-        List<RoleAssignmentResource> roleAssignmentList = new ArrayList<>();
-        roleAssignmentList.add(resource);
-        RoleAssignmentResponse response = new RoleAssignmentResponse();
-        response.setRoleAssignments(roleAssignmentList);
-        stubReturn200RoleAssignments(USER_ID, response);
-        DataStoreCaseDetails caseDetails = DataStoreCaseDetails.builder()
-            .caseTypeId(CASE_TYPE)
-            .jurisdiction(JURISDICTION)
-            .build();
-        stubReturn200CaseDetailsByCaseId(CASE_REFERENCE, caseDetails);
-        mockMvc.perform(post(url)
-                            .contentType(MediaType.APPLICATION_JSON_VALUE)
-                            .content(objectMapper.writeValueAsString(hearingRequest)))
-            .andExpect(status().is(201))
-            .andReturn();
-    }
-
-    @Test
     @Sql(scripts = {DELETE_HEARING_DATA_SCRIPT, CASE_HEARING_ACTUAL_HEARING})
     void shouldReturn404WhenHearingIdNotAvailableHearingCompletion() throws Exception {
         mockMvc.perform(post(hearingCompletion + "/2000000001")

--- a/src/main/java/uk/gov/hmcts/reform/hmc/data/OrganisationDetailEntity.java
+++ b/src/main/java/uk/gov/hmcts/reform/hmc/data/OrganisationDetailEntity.java
@@ -34,7 +34,7 @@ public class OrganisationDetailEntity {
     @Column(name = "organisation_type_code", nullable = false)
     private String organisationTypeCode;
 
-    @Column(name = "hmcts_organisation_reference", nullable = false)
+    @Column(name = "hmcts_organisation_reference")
     private String hmctsOrganisationReference;
 
     @OneToOne(fetch = FetchType.LAZY)

--- a/src/main/java/uk/gov/hmcts/reform/hmc/exceptions/ValidationError.java
+++ b/src/main/java/uk/gov/hmcts/reform/hmc/exceptions/ValidationError.java
@@ -61,7 +61,6 @@ public final class ValidationError {
     public static final String ORGANISATION_TYPE_NULL_EMPTY = "Organisation type can not be empty";
     public static final String ORGANISATION_TYPE_MAX_LENGTH = "Organisation type must not be more than 60 "
         + CHARACTERS_LONG;
-    public static final String CFT_ORG_ID_NULL_EMPTY = "CFT organisation id can not be empty";
     public static final String CFT_ORG_ID_MAX_LENGTH = "CFT organisation id must not be more than 60 "
         + CHARACTERS_LONG;
     public static final String UNAVAILABLE_FROM_DATE_EMPTY = "Unavailable from date can not be empty";

--- a/src/main/java/uk/gov/hmcts/reform/hmc/model/OrganisationDetails.java
+++ b/src/main/java/uk/gov/hmcts/reform/hmc/model/OrganisationDetails.java
@@ -19,7 +19,6 @@ public class OrganisationDetails {
     @Size(max = 60, message = ValidationError.ORGANISATION_TYPE_MAX_LENGTH)
     private String organisationType;
 
-    @NotEmpty(message = ValidationError.CFT_ORG_ID_NULL_EMPTY)
     @Size(max = 60, message = ValidationError.CFT_ORG_ID_MAX_LENGTH)
     private String cftOrganisationID;
 }

--- a/src/main/resources/db/migration/V20211001_21__HMAN-21-HearingService.sql
+++ b/src/main/resources/db/migration/V20211001_21__HMAN-21-HearingService.sql
@@ -223,7 +223,7 @@ CREATE TABLE public.organisation_detail (
                       tech_party_id bigint not null,
                       organisation_name varchar(2000) not null,
                       organisation_type_code varchar(60) not null,
-                      hmcts_organisation_reference varchar(60) not null
+                      hmcts_organisation_reference varchar(60)
 );
 
 ALTER TABLE ONLY public.organisation_detail

--- a/src/main/resources/db/migration/V20211001_21__HMAN-21-HearingService.sql
+++ b/src/main/resources/db/migration/V20211001_21__HMAN-21-HearingService.sql
@@ -223,7 +223,7 @@ CREATE TABLE public.organisation_detail (
                       tech_party_id bigint not null,
                       organisation_name varchar(2000) not null,
                       organisation_type_code varchar(60) not null,
-                      hmcts_organisation_reference varchar(60)
+                      hmcts_organisation_reference varchar(60) not null
 );
 
 ALTER TABLE ONLY public.organisation_detail

--- a/src/main/resources/db/migration/V20220411_152__HMAN-152-UpdateCftOrganistionId.sql
+++ b/src/main/resources/db/migration/V20220411_152__HMAN-152-UpdateCftOrganistionId.sql
@@ -1,0 +1,1 @@
+ALTER TABLE public.organisation_detail ALTER COLUMN hmcts_organisation_reference DROP NOT NULL;

--- a/src/test/java/uk/gov/hmcts/reform/hmc/controllers/HearingManagementControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/hmc/controllers/HearingManagementControllerTest.java
@@ -298,11 +298,6 @@ class HearingManagementControllerTest {
         }
     }
 
-    /**
-     * generate Hearing Response.
-     *
-     * @return hearingResponse Hearing Response
-     */
     private HearingResponse generateHearingResponse() {
         final long hearingId = 2000000000L;
         HearingResponse hearingResponse = new HearingResponse();
@@ -312,11 +307,6 @@ class HearingManagementControllerTest {
         return hearingResponse;
     }
 
-    /**
-     * generate Create Hearing Request.
-     *
-     * @return hearingRequest Create Hearing Request
-     */
     private HearingRequest generateHearingRequest(boolean isCftOrganisationIdNull) {
         HearingRequest hearingRequest = new HearingRequest();
         hearingRequest.setHearingDetails(TestingUtil.hearingDetails());

--- a/src/test/java/uk/gov/hmcts/reform/hmc/controllers/HearingManagementControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/hmc/controllers/HearingManagementControllerTest.java
@@ -74,13 +74,13 @@ class HearingManagementControllerTest {
         @Test
         void shouldReturn400_whenHearing_Details_Are_NotPresent() {
             // hearing request with no hearing details
-            HearingRequest hearingRequest = generateHearingRequest();
+            HearingRequest hearingRequest = generateHearingRequest(false);
             hearingRequest.setHearingDetails(null);
 
             HearingResponse hearingResponse = generateHearingResponse();
             when(hearingManagementService.saveHearingRequest(hearingRequest)).thenReturn(hearingResponse);
             doNothing().when(hearingManagementService).sendRequestToHmiAndQueue(
-                    hearingResponse.getHearingRequestId(), hearingRequest, REQUEST_HEARING);
+                hearingResponse.getHearingRequestId(), hearingRequest, REQUEST_HEARING);
 
             HearingManagementController controller = new HearingManagementController(hearingManagementService);
             controller.saveHearing(hearingRequest);
@@ -90,14 +90,15 @@ class HearingManagementControllerTest {
         @Test
         void shouldReturn400_whenCase_Details_Are_NotPresent() {
             // hearing request with no request details
-            HearingRequest hearingRequest = generateHearingRequest();
+            HearingRequest hearingRequest = generateHearingRequest(false);
             hearingRequest.setCaseDetails(null);
 
             HearingResponse hearingResponse = generateHearingResponse();
             doNothing().when(hearingManagementService).verifyAccess(any());
             when(hearingManagementService.saveHearingRequest(hearingRequest)).thenReturn(hearingResponse);
             doNothing().when(hearingManagementService).sendRequestToHmiAndQueue(1L, hearingRequest,
-                    REQUEST_HEARING);
+                                                                                REQUEST_HEARING
+            );
 
             HearingManagementController controller = new HearingManagementController(hearingManagementService);
             controller.saveHearing(hearingRequest);
@@ -107,13 +108,33 @@ class HearingManagementControllerTest {
         @Test
         void shouldReturn201_whenHearingRequestData() {
             // hearing request - valid
-            HearingRequest hearingRequest = generateHearingRequest();
+            HearingRequest hearingRequest = generateHearingRequest(false);
 
             HearingResponse hearingResponse = generateHearingResponse();
             when(hearingManagementService.saveHearingRequest(hearingRequest)).thenReturn(hearingResponse);
             doNothing().when(hearingManagementService).sendRequestToHmiAndQueue(
-                    hearingResponse.getHearingRequestId(), hearingRequest,
-                    REQUEST_HEARING);
+                hearingResponse.getHearingRequestId(), hearingRequest,
+                REQUEST_HEARING
+            );
+
+            HearingManagementController controller = new HearingManagementController(hearingManagementService);
+            controller.saveHearing(hearingRequest);
+            verify(hearingManagementService, times(1)).saveHearingRequest(any());
+            verify(hearingManagementService, times(1)).verifyAccess(any());
+        }
+
+
+        @Test
+        void shouldReturn201_whenHearingRequestDataWithOrgIdNull() {
+            // hearing request - valid
+            HearingRequest hearingRequest = generateHearingRequest(true);
+
+            HearingResponse hearingResponse = generateHearingResponse();
+            when(hearingManagementService.saveHearingRequest(hearingRequest)).thenReturn(hearingResponse);
+            doNothing().when(hearingManagementService).sendRequestToHmiAndQueue(
+                hearingResponse.getHearingRequestId(), hearingRequest,
+                REQUEST_HEARING
+            );
 
             HearingManagementController controller = new HearingManagementController(hearingManagementService);
             controller.saveHearing(hearingRequest);
@@ -134,8 +155,8 @@ class HearingManagementControllerTest {
             doNothing().when(hearingManagementService).verifyAccess(
                 hearingRequest.getCaseDetails().getCaseRef());
             doNothing().when(hearingManagementService).sendRequestToHmiAndQueue(
-                    hearingResponse.getHearingRequestId(), hearingRequest,
-                    REQUEST_HEARING
+                hearingResponse.getHearingRequestId(), hearingRequest,
+                REQUEST_HEARING
             );
             HearingManagementController controller = new HearingManagementController(hearingManagementService);
             controller.saveHearing(hearingRequest);
@@ -227,12 +248,32 @@ class HearingManagementControllerTest {
         @Test
         void shouldCallUpdateHearingRequest() {
             final long hearingId = 2000000000L;
-            UpdateHearingRequest hearingRequest = generateUpdateHearingRequest();
+            UpdateHearingRequest hearingRequest = generateUpdateHearingRequest(false);
             HearingResponse hearingResponse = generateHearingResponse();
             when(hearingManagementService.updateHearingRequest(hearingId, hearingRequest)).thenReturn(hearingResponse);
 
             doNothing().when(hearingManagementService).sendRequestToHmiAndQueue(1L, hearingRequest,
-                    AMEND_HEARING);
+                                                                                AMEND_HEARING
+            );
+            HearingManagementController controller = new HearingManagementController(hearingManagementService);
+            controller.updateHearing(hearingRequest, hearingId);
+            InOrder orderVerifier = Mockito.inOrder(hearingManagementService);
+            orderVerifier.verify(hearingManagementService).updateHearingRequest(hearingId, hearingRequest);
+            orderVerifier.verify(hearingManagementService)
+                .sendRequestToHmiAndQueue(hearingId, hearingRequest, AMEND_HEARING);
+            verifyNoMoreInteractions(hearingManagementService);
+        }
+
+        @Test
+        void shouldCallUpdateHearingRequestWithPartyWithOrgIdNull() {
+            final long hearingId = 2000000000L;
+            UpdateHearingRequest hearingRequest = generateUpdateHearingRequest(true);
+            HearingResponse hearingResponse = generateHearingResponse();
+            when(hearingManagementService.updateHearingRequest(hearingId, hearingRequest)).thenReturn(hearingResponse);
+
+            doNothing().when(hearingManagementService).sendRequestToHmiAndQueue(1L, hearingRequest,
+                                                                                AMEND_HEARING
+            );
             HearingManagementController controller = new HearingManagementController(hearingManagementService);
             controller.updateHearing(hearingRequest, hearingId);
             InOrder orderVerifier = Mockito.inOrder(hearingManagementService);
@@ -244,8 +285,8 @@ class HearingManagementControllerTest {
     }
 
     @Nested
-    @DisplayName("updateHearingCompletiong")
-    class UpdateHearingCompletiong {
+    @DisplayName("updateHearingCompletion")
+    class UpdateHearingCompletion {
 
         @Test
         void shouldInvokeHearingCompletion() {
@@ -259,6 +300,7 @@ class HearingManagementControllerTest {
 
     /**
      * generate Hearing Response.
+     *
      * @return hearingResponse Hearing Response
      */
     private HearingResponse generateHearingResponse() {
@@ -272,26 +314,42 @@ class HearingManagementControllerTest {
 
     /**
      * generate Create Hearing Request.
+     *
      * @return hearingRequest Create Hearing Request
      */
-    private HearingRequest generateHearingRequest() {
+    private HearingRequest generateHearingRequest(boolean isCftOrganisationIdNull) {
         HearingRequest hearingRequest = new HearingRequest();
         hearingRequest.setHearingDetails(TestingUtil.hearingDetails());
         hearingRequest.setCaseDetails(TestingUtil.caseDetails());
+        hearingRequest.setPartyDetails(TestingUtil.partyDetails());
+        hearingRequest.getPartyDetails().get(0).setIndividualDetails(TestingUtil.individualDetails());
+        if (isCftOrganisationIdNull) {
+            hearingRequest.getPartyDetails().get(1).setOrganisationDetails(TestingUtil.organisationDetailsIdNull());
+        } else {
+            hearingRequest.getPartyDetails().get(1).setOrganisationDetails(TestingUtil.organisationDetails());
+        }
         return hearingRequest;
     }
 
     /**
      * generate Create Hearing Request.
+     *
      * @return hearingRequest Create Hearing Request
      */
-    private UpdateHearingRequest generateUpdateHearingRequest() {
+    private UpdateHearingRequest generateUpdateHearingRequest(boolean isCftOrganisationIdNull) {
         UpdateHearingRequest hearingRequest = new UpdateHearingRequest();
         RequestDetails requestDetails = new RequestDetails();
         requestDetails.setVersionNumber(2);
         hearingRequest.setRequestDetails(requestDetails);
         hearingRequest.setHearingDetails(TestingUtil.hearingDetails());
         hearingRequest.setCaseDetails(TestingUtil.caseDetails());
+        hearingRequest.setPartyDetails(TestingUtil.partyDetails());
+        hearingRequest.getPartyDetails().get(0).setIndividualDetails(TestingUtil.individualDetails());
+        if (isCftOrganisationIdNull) {
+            hearingRequest.getPartyDetails().get(1).setOrganisationDetails(TestingUtil.organisationDetailsIdNull());
+        } else {
+            hearingRequest.getPartyDetails().get(1).setOrganisationDetails(TestingUtil.organisationDetails());
+        }
         return hearingRequest;
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/hmc/utils/TestingUtil.java
+++ b/src/test/java/uk/gov/hmcts/reform/hmc/utils/TestingUtil.java
@@ -244,6 +244,13 @@ public class TestingUtil {
         return organisationDetails;
     }
 
+    public static OrganisationDetails organisationDetailsIdNull() {
+        OrganisationDetails organisationDetails = new OrganisationDetails();
+        organisationDetails.setName("name");
+        organisationDetails.setOrganisationType("type");
+        return organisationDetails;
+    }
+
     public static HearingEntity hearingEntity() {
         HearingEntity hearingEntity = new HearingEntity();
         hearingEntity.setId(1L);
@@ -688,19 +695,20 @@ public class TestingUtil {
         return entity1;
     }
 
-    public static UpdateHearingRequest updateHearingRequestWithPartyDetails() {
+    public static UpdateHearingRequest updateHearingRequestWithPartyDetails(boolean isCftOrganisationIdNull) {
         RequestDetails requestDetails = new RequestDetails();
         requestDetails.setVersionNumber(1);
         UpdateHearingRequest request = new UpdateHearingRequest();
         request.setRequestDetails(requestDetails);
         request.setHearingDetails(hearingDetailsWithAllFields());
         request.setCaseDetails(caseDetails());
-        request.setPartyDetails(partyDetailsWith2Parties());
+        request.setPartyDetails(partyDetailsWith2Parties(isCftOrganisationIdNull));
 
         return request;
     }
 
-    private static List<PartyDetails> partyDetailsWith2Parties() {
+
+    private static List<PartyDetails> partyDetailsWith2Parties(boolean isCftOrganisationIdNull) {
         PartyDetails partyDetails1 = new PartyDetails();
         partyDetails1.setPartyID("P1");
         partyDetails1.setPartyType("ind");
@@ -713,7 +721,11 @@ public class TestingUtil {
         partyDetails2.setPartyID("P2");
         partyDetails2.setPartyType("IND");
         partyDetails2.setPartyRole("DEF2");
-        partyDetails2.setOrganisationDetails(organisationDetails());
+        if (isCftOrganisationIdNull) {
+            partyDetails2.setOrganisationDetails(organisationDetailsIdNull());
+        } else {
+            partyDetails2.setOrganisationDetails(organisationDetails());
+        }
 
         List<PartyDetails> partyDetails = Lists.newArrayList(partyDetails1, partyDetails2);
         return partyDetails;
@@ -777,9 +789,9 @@ public class TestingUtil {
 
     public static PanelRequirements panelRequirementsList() {
         PanelRequirements panelRequirements = new PanelRequirements();
-        panelRequirements.setRoleType(Arrays.asList("RoleType1","RoleType2"));
-        panelRequirements.setAuthorisationTypes(Arrays.asList("AuthorisationType1","AuthorisationType2"));
-        panelRequirements.setAuthorisationSubType(Arrays.asList("AuthorisationSubType2","AuthorisationSubType2"));
+        panelRequirements.setRoleType(Arrays.asList("RoleType1", "RoleType2"));
+        panelRequirements.setAuthorisationTypes(Arrays.asList("AuthorisationType1", "AuthorisationType2"));
+        panelRequirements.setAuthorisationSubType(Arrays.asList("AuthorisationSubType2", "AuthorisationSubType2"));
         return panelRequirements;
     }
 
@@ -803,7 +815,7 @@ public class TestingUtil {
         individualDetails.setLastName("Jason");
         individualDetails.setPreferredHearingChannel("channel 5");
         individualDetails.setInterpreterLanguage("French");
-        individualDetails.setReasonableAdjustments(Arrays.asList("Adjust1","Adjust2","Adjust3"));
+        individualDetails.setReasonableAdjustments(Arrays.asList("Adjust1", "Adjust2", "Adjust3"));
         individualDetails.setVulnerableFlag(false);
         individualDetails.setVulnerabilityDetails("More vulnerable");
         individualDetails.setHearingChannelPhone("01111111111");

--- a/src/test/java/uk/gov/hmcts/reform/hmc/utils/TestingUtil.java
+++ b/src/test/java/uk/gov/hmcts/reform/hmc/utils/TestingUtil.java
@@ -249,6 +249,7 @@ public class TestingUtil {
         OrganisationDetails organisationDetails = new OrganisationDetails();
         organisationDetails.setName("name");
         organisationDetails.setOrganisationType("type");
+        organisationDetails.setCftOrganisationID(null);
         return organisationDetails;
     }
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

[HMAN-152 Make cftOrganisationId element non-mandatory in PUT/POST hearing request payload](https://tools.hmcts.net/jira/browse/HMAN-152)



### Change description ###

Removes cftOrganisationId as a mandatory field for the PUT and POST request payload so as to allow to be null

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
