### PR TITLE
HMAN-194 - Remove need for Content-Type on DELETE linkedHearingGroup

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/hmc/controllers/LinkedHearingGroupController.java
+++ b/src/main/java/uk/gov/hmcts/reform/hmc/controllers/LinkedHearingGroupController.java
@@ -22,8 +22,7 @@ public class LinkedHearingGroupController {
         this.linkedHearingGroupService = linkedHearingGroupService;
     }
 
-    @DeleteMapping(path = "/linkedHearingGroup/{id}", consumes = APPLICATION_JSON_VALUE,
-        produces = APPLICATION_JSON_VALUE)
+    @DeleteMapping(path = "/linkedHearingGroup/{id}", produces = APPLICATION_JSON_VALUE)
     @ResponseStatus(HttpStatus.OK)
     @ApiResponses(value = {
         @ApiResponse(code = 200, message = "Hearing group deletion processed"),


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/HMAN-194


### Change description ###
Remove need for Content-Type on DELETE linkedHearingGroup


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
