### PR TITLE
HMAN-196 - add condition to enhance Access Control for GET /hearings

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/hmc/controllers/HearingManagementController.java
+++ b/src/main/java/uk/gov/hmcts/reform/hmc/controllers/HearingManagementController.java
@@ -138,6 +138,9 @@ public class HearingManagementController {
             accessControlService.verifyCaseAccess(ccdCaseRef, Lists.newArrayList(
                 HEARING_VIEWER,
                 LISTED_HEARING_VIEWER));
+        } else if (status == null || status.isEmpty()) {
+            accessControlService.verifyCaseAccess(ccdCaseRef, Lists.newArrayList(LISTED_HEARING_VIEWER));
+            status = HearingStatus.LISTED.name();
         } else {
             accessControlService.verifyCaseAccess(ccdCaseRef, Lists.newArrayList(HEARING_VIEWER));
         }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/HMAN-196

### Change description ###
Enhance Access Control for GET /hearings.

When the optional "status" param for GET /hearings is not provided and the user only has listed-hearing-viewer, access control still passes. We should be searching only for LISTED hearings in this scenario.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
