### PR TITLE
CCD-3112: Updated spring-framework.version to 5.3.19, removed suppression for CVE-2022-22968

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -233,7 +233,7 @@ def versions = [
   serviceAuthVersion: '4.0.3'
 ]
 
-ext['spring-framework.version'] = '5.3.18'
+ext['spring-framework.version'] = '5.3.19'
 ext['log4j2.version'] = '2.17.1'
 ext['jackson.version'] = '2.13.2'
 

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -24,11 +24,9 @@
     <notes>
       <![CDATA[Temporary suppressions pending investigation]]>
     </notes>
-    <cve>CVE-2022-22968</cve>
     <cve>CVE-2022-22965</cve>
     <cve>CVE-2022-21724</cve>
     <cve>CVE-2020-36518</cve>
-    <cve>CVE-2022-22968</cve>
   </suppress>
   <suppress>
     <notes>
@@ -39,11 +37,5 @@
     <packageUrl regex="true">^pkg:maven/org\.postgresql/postgresql@.*$</packageUrl>
     <cve>CVE-2022-21724</cve>
   </suppress>
-  <suppress until="2022-05-25">
-    <notes><![CDATA[
-   file name: spring-core-5.3.18.jar
-   ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-core@.*$</packageUrl>
-    <cve>CVE-2022-22968</cve>
-  </suppress>
+
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/CCD-3112

### Change description ###

Updated spring-framework.version to 5.3.19, removed suppression for CVE-2022-22968

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
