### PR TITLE
CCD-3088 Remove redundant entries from suppression files

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -25,7 +25,6 @@
       <![CDATA[Temporary suppressions pending investigation]]>
     </notes>
     <cve>CVE-2022-22965</cve>
-    <cve>CVE-2020-36518</cve>
   </suppress>
   <suppress until="2022-06-25">
     <notes><![CDATA[


### PR DESCRIPTION
CCD-3088 Remove redundant entries from suppression files - removed CVE-2022-22965 and CVE-2020-36518
https://tools.hmcts.net/jira/browse/CCD-3088

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
