### PR TITLE
CVE-2022-24823 : hmc-cft-hearing-service fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -229,7 +229,7 @@ def versions = [
   springCloud     : '2020.0.1',
   springfoxSwagger: '3.0.0',
   testcontainers  : '1.15.2',
-  netty           : '4.1.75.Final',
+  netty           : '4.1.77.Final',
   serviceAuthVersion: '4.0.3'
 ]
 

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -37,7 +37,4 @@
     <packageUrl regex="true">^pkg:maven/org\.postgresql/postgresql@.*$</packageUrl>
     <cve>CVE-2022-21724</cve>
   </suppress>
-  <suppress until="2022-06-25">
-     <cve>CVE-2022-24823</cve>
-  </suppress>
 </suppressions>


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/CCD-3185

upgrading netty version to 4.1.77.Final.
Netty is an open-source, asynchronous event-driven network application framework. The package `io.netty:netty-codec-http` prior to version 4.1.77.Final contains an insufficient fix for CVE-2021-21290

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
