### PR TITLE
CCD-3280: Add ARGs for builder stage paths to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,12 +8,18 @@ FROM hmctspublic.azurecr.io/base/java:openjdk-11-distroless-1.4
 
 COPY lib/AI-Agent.xml /opt/app/
 
-COPY --from=builder application/ /opt/app/
-COPY --from=builder dependencies/ /opt/app/
+# The following layer ARGs are only needed to stop Fortify flagging an issue with the COPY instructions
+ARG DIR_LAYER_APPLICATION=application/
+ARG DIR_LAYER_DEPENDECIES=dependencies/
+ARG DIR_LAYER_SPRING_BOOT_LOADER=spring-boot-loader/
+ARG DIR_LAYER_SNAPSHOT_DEPENDENCIES=snapshot-dependencies/
+
+COPY --from=builder ${DIR_LAYER_APPLICATION} /opt/app/
+COPY --from=builder ${DIR_LAYER_DEPENDECIES} /opt/app/
 # Add 'CMD true or RUN true' if consecutive COPY commands are failing in case (intermittently).
 # See https://github.com/moby/moby/issues/37965#issuecomment-771526632
-COPY --from=builder spring-boot-loader/ /opt/app/
-COPY --from=builder snapshot-dependencies/ /opt/app/
+COPY --from=builder ${DIR_LAYER_SPRING_BOOT_LOADER} /opt/app/
+COPY --from=builder ${DIR_LAYER_SNAPSHOT_DEPENDENCIES} /opt/app/
 
 EXPOSE 4561
 ENTRYPOINT ["/usr/bin/java", "org.springframework.boot.loader.JarLauncher"]


### PR DESCRIPTION
### JIRA link (if applicable) ###
CCD-3280 (https://tools.hmcts.net/jira/browse/CCD-3280)


### Change description ###
Add ARGs to Dockerfile for builder stage paths used in COPY instructions.  These are only needed to stop Fortify flagging a sensitive directory issue with the COPY instructions.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
