### PR TITLE
HMAN-215 - Reduce number of hearing sessions stored in DB

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -367,6 +367,7 @@ dependencies {
   testImplementation group: 'com.github.hmcts', name: 'befta-fw', version: '8.7.1'
 
   compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.7'
+  compile group: 'org.apache.commons', name: 'commons-collections4', version: '4.1'
 
   compile group: 'org.flywaydb', name: 'flyway-core', version: '7.7.0'
   compileOnly group: 'org.mapstruct', name: 'mapstruct', version: versions.mapstruct

--- a/src/integrationTest/java/uk/gov/hmcts/reform/hmc/config/MessageProcessorIT.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/hmc/config/MessageProcessorIT.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.slf4j.LoggerFactory;
@@ -18,17 +19,29 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
 import org.springframework.test.context.jdbc.Sql;
 import uk.gov.hmcts.reform.hmc.BaseTest;
+import uk.gov.hmcts.reform.hmc.data.HearingDayDetailsEntity;
+import uk.gov.hmcts.reform.hmc.repository.HearingDayDetailsRepository;
 import uk.gov.hmcts.reform.hmc.service.InboundQueueService;
 import uk.gov.hmcts.reform.hmc.service.InboundQueueServiceImpl;
 
+import javax.inject.Inject;
+import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Spliterator;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
+import static java.time.LocalDateTime.parse;
+import static java.util.stream.StreamSupport.stream;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class MessageProcessorIT extends BaseTest {
+
+    @Inject
+    private HearingDayDetailsRepository hearingDayDetailsRepository;
 
     @MockBean
     private MessageSenderToTopicConfiguration messageSenderConfiguration;
@@ -47,209 +60,97 @@ class MessageProcessorIT extends BaseTest {
     private static final String HEARING_ID = "hearing_id";
     private static final String DELETE_HEARING_DATA_SCRIPT = "classpath:sql/delete-hearing-tables.sql";
     private static final String GET_HEARINGS_DATA_SCRIPT = "classpath:sql/get-caseHearings_request_hmi.sql";
-    JsonNode jsonNode = OBJECT_MAPPER.readTree("{\n"
-                                                   + "  \"meta\": {\n"
-                                                   + "    \"transactionIdCaseHQ\": \"<transactionIdCaseHQ>\",\n"
-                                                   + "    \"timestamp\": \"2021-08-10T12:20:00\"\n"
-                                                   + "  },\n"
-                                                   + "  \"hearing\": {\n"
-                                                   + "    \"listingRequestId\": \"<listingRequestId>\",\n"
-                                                   + "    \"hearingCaseVersionId\": 1,\n"
-                                                   + "    \"hearingCaseIdHMCTS\": \"<hearingCaseIdHMCTS>\",\n"
-                                                   + "    \"hearingCaseJurisdiction\": {\n"
-                                                   + "      \"test\": \"value\"\n"
-                                                   + "    },\n"
-                                                   + "    \"hearingCaseStatus\": {\n"
-                                                   + "      \"code\": \"100\",\n"
-                                                   + "      \"description\": \"<description>\"\n"
-                                                   + "    },\n"
-                                                   + "    \"hearingIdCaseHQ\": \"<hearingIdCaseHQ>\",\n"
-                                                   + "    \"hearingType\": {\n"
-                                                   + "      \"test\": \"value\"\n"
-                                                   + "    },\n"
-                                                   + "    \"hearingStatus\": {\n"
-                                                   + "      \"code\": \"DRAFT\",\n"
-                                                   + "      \"description\": \"<descrixption>\"\n"
-                                                   + "    },\n"
-                                                   + "    \"hearingCancellationReason\""
-                                                   + ": \"<hearingCancellationReason>\",\n"
-                                                   + "    \"hearingStartTime\": \"2021-08-10T12:20:00\",\n"
-                                                   + "    \"hearingEndTime\": \"2021-08-10T12:20:00\",\n"
-                                                   + "    \"hearingPrivate\": true,\n"
-                                                   + "    \"hearingRisk\": true,\n"
-                                                   + "    \"hearingTranslatorRequired\": false,\n"
-                                                   + "    \"hearingCreatedDate\": \"2021-08-10T12:20:00\",\n"
-                                                   + "    \"hearingCreatedBy\": \"testuser\",\n"
-                                                   + "    \"hearingVenue\": {\n"
-                                                   + "      \"locationIdCaseHQ\": \"<locationIdCaseHQ>\",\n"
-                                                   + "      \"locationName\": \"<locationName>\",\n"
-                                                   + "      \"locationRegion\": \"<locationRegion>\",\n"
-                                                   + "      \"locationCluster\": \"<locationCluster>\",\n"
-                                                   + "      \"locationReferences\": [{\n"
-                                                   + "        \"key\": \"EPIMS\",\n"
-                                                   + "        \"value\": \"<value>\"\n"
-                                                   + "      }]\n"
-                                                   + "    },\n"
-                                                   + "    \"hearingRoom\": {\n"
-                                                   + "      \"locationIdCaseHQ\": \"<locationIdCaseHQ>\",\n"
-                                                   + "      \"locationName\": \"<roomName>\",\n"
-                                                   + "      \"locationRegion\": {\n"
-                                                   + "        \"key\": \"<key>\",\n"
-                                                   + "        \"value\": \"<value>\"\n"
-                                                   + "      },\n"
-                                                   + "      \"locationCluster\": {\n"
-                                                   + "        \"key\": \"<key>\",\n"
-                                                   + "        \"value\": \"<value>\"\n"
-                                                   + "      },\n"
-                                                   + "      \"locationReferences\": {\n"
-                                                   + "        \"key\": \"<key>\",\n"
-                                                   + "        \"value\": \"<value>\"\n"
-                                                   + "      }\n"
-                                                   + "    },\n"
-                                                   + "    \"hearingAttendees\": [{\n"
-                                                   + "      \"entityIdCaseHQ\": \"<id>\",\n"
-                                                   + "      \"entityId\": \"<id>\",\n"
-                                                   + "      \"entityType\": \"<type>\",\n"
-                                                   + "      \"entityClass\": \"<class>\",\n"
-                                                   + "      \"entityRole\": {\n"
-                                                   + "        \"key\": \"<key>\",\n"
-                                                   + "        \"value\": \"<value>\"\n"
-                                                   + "      },\n"
-                                                   + "      \"hearingChannel\": {\n"
-                                                   + "        \"code\": \"<key>\",\n"
-                                                   + "        \"description\": \"<value>\"\n"
-                                                   + "      }\n"
-                                                   + "    }],\n"
-                                                   + "    \"hearingJohs\": [{\n"
-                                                   + "      \"johId\": \"<johId>\",\n"
-                                                   + "      \"johCode\": \"<johCode>\",\n"
-                                                   + "      \"johName\": \"<johName>\",\n"
-                                                   + "      \"johPosition\": {\n"
-                                                   + "        \"key\": \"<key>\",\n"
-                                                   + "        \"value\": \"<value>\"\n"
-                                                   + "      },\n"
-                                                   + "      \"isPresiding\": false\n"
-                                                   + "    }],\n"
-                                                   + "    \"hearingSessions\": [\n"
-                                                   + "    ]\n"
-                                                   + "  }\n"
-                                                   + "}");
+    private static final String HEARING = "{\n"
+            + "  \"meta\": {\n"
+           + "    \"transactionIdCaseHQ\": \"<transactionIdCaseHQ>\",\n"
+           + "    \"timestamp\": \"2021-08-10T12:20:00\"\n"
+           + "  },\n"
+           + "  \"hearing\": {\n"
+           + "    \"listingRequestId\": \"<listingRequestId>\",\n"
+           + "    \"hearingCaseVersionId\": %s,\n"
+           + "    \"hearingCaseIdHMCTS\": \"<hearingCaseIdHMCTS>\",\n"
+           + "    \"hearingCaseJurisdiction\": {\n"
+           + "      \"test\": \"value\"\n"
+           + "    },\n"
+           + "    \"hearingCaseStatus\": {\n"
+           + "      \"code\": \"100\",\n"
+           + "      \"description\": \"<description>\"\n"
+           + "    },\n"
+           + "    \"hearingIdCaseHQ\": \"<hearingIdCaseHQ>\",\n"
+           + "    \"hearingType\": {\n"
+           + "      \"test\": \"value\"\n"
+           + "    },\n"
+           + "    \"hearingStatus\": {\n"
+           + "      \"code\": \"DRAFT\",\n"
+           + "      \"description\": \"<descrixption>\"\n"
+           + "    },\n"
+           + "    \"hearingCancellationReason\""
+           + ": \"<hearingCancellationReason>\",\n"
+           + "    \"hearingStartTime\": \"2021-08-10T12:20:00\",\n"
+           + "    \"hearingEndTime\": \"2021-08-10T12:20:00\",\n"
+           + "    \"hearingPrivate\": true,\n"
+           + "    \"hearingRisk\": true,\n"
+           + "    \"hearingTranslatorRequired\": false,\n"
+           + "    \"hearingCreatedDate\": \"2021-08-10T12:20:00\",\n"
+           + "    \"hearingCreatedBy\": \"testuser\",\n"
+           + "    \"hearingVenue\": {\n"
+           + "      \"locationIdCaseHQ\": \"<locationIdCaseHQ>\",\n"
+           + "      \"locationName\": \"<locationName>\",\n"
+           + "      \"locationRegion\": \"<locationRegion>\",\n"
+           + "      \"locationCluster\": \"<locationCluster>\",\n"
+           + "      \"locationReferences\": [{\n"
+           + "        \"key\": \"EPIMS\",\n"
+           + "        \"value\": \"<value>\"\n"
+           + "      }]\n"
+           + "    },\n"
+           + "    \"hearingRoom\": {\n"
+           + "      \"locationIdCaseHQ\": \"<locationIdCaseHQ>\",\n"
+           + "      \"locationName\": \"<roomName>\",\n"
+           + "      \"locationRegion\": {\n"
+           + "        \"key\": \"<key>\",\n"
+           + "        \"value\": \"<value>\"\n"
+           + "      },\n"
+           + "      \"locationCluster\": {\n"
+           + "        \"key\": \"<key>\",\n"
+           + "        \"value\": \"<value>\"\n"
+           + "      },\n"
+           + "      \"locationReferences\": {\n"
+           + "        \"key\": \"<key>\",\n"
+           + "        \"value\": \"<value>\"\n"
+           + "      }\n"
+           + "    },\n"
+           + "    \"hearingAttendees\": [{\n"
+           + "      \"entityIdCaseHQ\": \"<id>\",\n"
+           + "      \"entityId\": \"<id>\",\n"
+           + "      \"entityType\": \"<type>\",\n"
+           + "      \"entityClass\": \"<class>\",\n"
+           + "      \"entityRole\": {\n"
+           + "        \"key\": \"<key>\",\n"
+           + "        \"value\": \"<value>\"\n"
+           + "      },\n"
+           + "      \"hearingChannel\": {\n"
+           + "        \"code\": \"<key>\",\n"
+           + "        \"description\": \"<value>\"\n"
+           + "      }\n"
+           + "    }],\n"
+           + "    \"hearingJohs\": [{\n"
+           + "      \"johId\": \"<johId>\",\n"
+           + "      \"johCode\": \"<johCode>\",\n"
+           + "      \"johName\": \"<johName>\",\n"
+           + "      \"johPosition\": {\n"
+           + "        \"key\": \"<key>\",\n"
+           + "        \"value\": \"<value>\"\n"
+           + "      },\n"
+           + "      \"isPresiding\": false\n"
+           + "    }],\n"
+           + "    \"hearingSessions\": %s\n"
+           + "  }\n"
+           + "}";
 
-    JsonNode jsonMisMatchOnRequestVersion = OBJECT_MAPPER.readTree("{\n"
-                                                   + "  \"meta\": {\n"
-                                                   + "    \"transactionIdCaseHQ\": \"<transactionIdCaseHQ>\",\n"
-                                                   + "    \"timestamp\": \"2021-08-10T12:20:00\"\n"
-                                                   + "  },\n"
-                                                   + "  \"hearing\": {\n"
-                                                   + "    \"listingRequestId\": \"<listingRequestId>\",\n"
-                                                   + "    \"hearingCaseVersionId\": 10,\n"
-                                                   + "    \"hearingCaseIdHMCTS\": \"<hearingCaseIdHMCTS>\",\n"
-                                                   + "    \"hearingCaseJurisdiction\": {\n"
-                                                   + "      \"test\": \"value\"\n"
-                                                   + "    },\n"
-                                                   + "    \"hearingCaseStatus\": {\n"
-                                                   + "      \"code\": \"100\",\n"
-                                                   + "      \"description\": \"<description>\"\n"
-                                                   + "    },\n"
-                                                   + "    \"hearingIdCaseHQ\": \"<hearingIdCaseHQ>\",\n"
-                                                   + "    \"hearingType\": {\n"
-                                                   + "      \"test\": \"value\"\n"
-                                                   + "    },\n"
-                                                   + "    \"hearingStatus\": {\n"
-                                                   + "      \"code\": \"DRAFT\",\n"
-                                                   + "      \"description\": \"<descrixption>\"\n"
-                                                   + "    },\n"
-                                                   + "    \"hearingCancellationReason\""
-                                                   + ": \"<hearingCancellationReason>\",\n"
-                                                   + "    \"hearingStartTime\": \"2021-08-10T12:20:00\",\n"
-                                                   + "    \"hearingEndTime\": \"2021-08-10T12:20:00\",\n"
-                                                   + "    \"hearingPrivate\": true,\n"
-                                                   + "    \"hearingRisk\": true,\n"
-                                                   + "    \"hearingTranslatorRequired\": false,\n"
-                                                   + "    \"hearingCreatedDate\": \"2021-08-10T12:20:00\",\n"
-                                                   + "    \"hearingCreatedBy\": \"testuser\",\n"
-                                                   + "    \"hearingVenue\": {\n"
-                                                   + "      \"locationIdCaseHQ\": \"<locationIdCaseHQ>\",\n"
-                                                   + "      \"locationName\": \"<locationName>\",\n"
-                                                   + "      \"locationRegion\": \"<locationRegion>\",\n"
-                                                   + "      \"locationCluster\": \"<locationCluster>\",\n"
-                                                   + "      \"locationReferences\": [{\n"
-                                                   + "        \"key\": \"EPIMS\",\n"
-                                                   + "        \"value\": \"<value>\"\n"
-                                                   + "      }]\n"
-                                                   + "    },\n"
-                                                   + "    \"hearingRoom\": {\n"
-                                                   + "      \"locationIdCaseHQ\": \"<locationIdCaseHQ>\",\n"
-                                                   + "      \"locationName\": \"<roomName>\",\n"
-                                                   + "      \"locationRegion\": {\n"
-                                                   + "        \"key\": \"<key>\",\n"
-                                                   + "        \"value\": \"<value>\"\n"
-                                                   + "      },\n"
-                                                   + "      \"locationCluster\": {\n"
-                                                   + "        \"key\": \"<key>\",\n"
-                                                   + "        \"value\": \"<value>\"\n"
-                                                   + "      },\n"
-                                                   + "      \"locationReferences\": {\n"
-                                                   + "        \"key\": \"<key>\",\n"
-                                                   + "        \"value\": \"<value>\"\n"
-                                                   + "      }\n"
-                                                   + "    },\n"
-                                                   + "    \"hearingAttendees\": [{\n"
-                                                   + "      \"entityIdCaseHQ\": \"<id>\",\n"
-                                                   + "      \"entityId\": \"<id>\",\n"
-                                                   + "      \"entityType\": \"<type>\",\n"
-                                                   + "      \"entityClass\": \"<class>\",\n"
-                                                   + "      \"entityRole\": {\n"
-                                                   + "        \"key\": \"<key>\",\n"
-                                                   + "        \"value\": \"<value>\"\n"
-                                                   + "      },\n"
-                                                   + "      \"hearingChannel\": {\n"
-                                                   + "        \"code\": \"<key>\",\n"
-                                                   + "        \"description\": \"<value>\"\n"
-                                                   + "      }\n"
-                                                   + "    }],\n"
-                                                   + "    \"hearingJohs\": [{\n"
-                                                   + "      \"johId\": \"<johId>\",\n"
-                                                   + "      \"johCode\": \"<johCode>\",\n"
-                                                   + "      \"johName\": \"<johName>\",\n"
-                                                   + "      \"johPosition\": {\n"
-                                                   + "        \"key\": \"<key>\",\n"
-                                                   + "        \"value\": \"<value>\"\n"
-                                                   + "      },\n"
-                                                   + "      \"isPresiding\": false\n"
-                                                   + "    }],\n"
-                                                   + "    \"hearingSessions\": [{\n"
-                                                   + "      \"hearingStartTime\": \"2021-08-10T12:20:00\",\n"
-                                                   + "      \"hearingEndTime\": \"2021-08-10T12:20:00\",\n"
-                                                   + "      \"hearingVenue\": {\n"
-                                                   + "          \"locationIdCaseHQ\": \"<locationIdCaseHQ>\",\n"
-                                                   + "          \"locationName\": \"<locationName>\",\n"
-                                                   + "          \"locationRegion\": \"<locationRegion>\",\n"
-                                                   + "          \"locationCluster\": \"<locationCluster>\",\n"
-                                                   + "          \"locationReferences\": [{\n"
-                                                   + "           \"key\": \"EPIMS\",\n"
-                                                   + "          \"value\": \"<value>\"\n"
-                                                   + "       }]\n"
-                                                   + "      },\n"
-                                                   + "      \"hearingRoom\": {\n"
-                                                   + "        \"locationIdCaseHQ\": \"<locationIdCaseHQ>\",\n"
-                                                   + "        \"locationName\": \"<roomName>\",\n"
-                                                   + "        \"locationRegion\": {\n"
-                                                   + "           \"key\": \"<key>\",\n"
-                                                   + "           \"value\": \"<value>\"\n"
-                                                   + "         },\n"
-                                                   + "        \"locationCluster\": {\n"
-                                                   + "          \"key\": \"<key>\",\n"
-                                                   + "          \"value\": \"<value>\"\n"
-                                                   + "         },\n"
-                                                   + "        \"locationReferences\": {\n"
-                                                   + "          \"key\": \"<key>\",\n"
-                                                   + "         \"value\": \"<value>\"\n"
-                                                   + "        }\n"
-                                                   + "        }\n"
-                                                   + "    }]\n"
-                                                   + "  }\n"
-                                                   + "}");
+    JsonNode jsonNode = OBJECT_MAPPER.readTree(String.format(HEARING, 1, "[\n]"));
+
+    JsonNode jsonMisMatchOnRequestVersion = OBJECT_MAPPER.readTree(String.format(HEARING, 10,
+            createHearingSessions(List.of("2021-08-10T12:20:00"), List.of("2021-08-10T12:20:00"))));
 
     @Autowired
     private InboundQueueService inboundQueueService;
@@ -257,9 +158,55 @@ class MessageProcessorIT extends BaseTest {
     MessageProcessorIT() throws JsonProcessingException {
     }
 
+    private String createHearingSessions(List<String> startTimes, List<String> endTimes) {
+        assertEquals(startTimes.size(), endTimes.size());
+        return "[\n" + IntStream.range(0, startTimes.size()).mapToObj(i ->
+                createHearingSession(startTimes.get(i), endTimes.get(i))
+        ).collect(Collectors.joining(",")) + "]";
+    }
+
+    private String createHearingSession(String startTime, String endTime) {
+        return String.format("{\n"
+                        + " \"hearingStartTime\": \"%s\",\n"
+                        + " \"hearingEndTime\": \"%s\",\n"
+                        + " \"hearingVenue\": {\n"
+                        + "     \"locationIdCaseHQ\": \"<locationIdCaseHQ>\",\n"
+                        + "     \"locationName\": \"<locationName>\",\n"
+                        + "     \"locationRegion\": \"<locationRegion>\",\n"
+                        + "     \"locationCluster\": \"<locationCluster>\",\n"
+                        + "     \"locationReferences\": [{\n"
+                        + "         \"key\": \"EPIMS\",\n"
+                        + "         \"value\": \"<value>\"\n"
+                        + "     }]\n"
+                        + " },\n"
+                        + " \"hearingRoom\": {\n"
+                        + "     \"locationIdCaseHQ\": \"<locationIdCaseHQ>\",\n"
+                        + "     \"locationName\": \"<roomName>\",\n"
+                        + "     \"locationRegion\": {\n"
+                        + "     \"key\": \"<key>\",\n"
+                        + "         \"value\": \"<value>\"\n"
+                        + "     },\n"
+                        + "     \"locationCluster\": {\n"
+                        + "         \"key\": \"<key>\",\n"
+                        + "         \"value\": \"<value>\"\n"
+                        + "     },\n"
+                        + "     \"locationReferences\": {\n"
+                        + "         \"key\": \"<key>\",\n"
+                        + "         \"value\": \"<value>\"\n"
+                        + "     }\n"
+                        + " }\n"
+                        + "}",
+                startTime,
+                endTime);
+    }
+
     @Test
     @Sql(scripts = {DELETE_HEARING_DATA_SCRIPT, GET_HEARINGS_DATA_SCRIPT})
     void shouldInitiateRequest() {
+        initiateRequest(jsonNode);
+    }
+
+    private void initiateRequest(JsonNode jsonNode) {
         Map<String, Object> applicationProperties = new HashMap<>();
         applicationProperties.put(HEARING_ID, "2000000000");
         applicationProperties.put(MESSAGE_TYPE, MessageType.HEARING_RESPONSE);
@@ -354,8 +301,6 @@ class MessageProcessorIT extends BaseTest {
                          + "Cannot find request version 10 for hearing 2000000000",
                      logsListMessageProcessor.get(0).getMessage());
     }
-
-
 
     @Test
     @Sql(scripts = {DELETE_HEARING_DATA_SCRIPT, GET_HEARINGS_DATA_SCRIPT})
@@ -484,5 +429,81 @@ class MessageProcessorIT extends BaseTest {
         assertEquals(Level.ERROR, logsListMessageProcessor.get(0).getLevel());
         assertEquals("Error for message with id null with error Invalid hearing Id",
                      logsListMessageProcessor.get(0).getMessage());
+    }
+
+    @Test
+    @Sql(scripts = {DELETE_HEARING_DATA_SCRIPT, GET_HEARINGS_DATA_SCRIPT})
+    void shouldInitiateRequest_shouldStoreSingleHearingSessionForDay() throws JsonProcessingException {
+
+        JsonNode hearingSessionsJsonNode = OBJECT_MAPPER.readTree(String.format(HEARING, 1,
+                createHearingSessions(
+                        List.of("2022-02-10T10:30:00", "2022-02-10T12:00:00", "2022-02-10T14:30:00"),
+                        List.of("2022-02-10T11:30:00", "2022-02-10T12:30:00", "2022-02-10T16:30:00"))
+        ));
+
+        initiateRequest(hearingSessionsJsonNode);
+
+        final Iterable<HearingDayDetailsEntity> hearingDayDetailsEntities = hearingDayDetailsRepository.findAll();
+
+        assertEquals(1, hearingDayDetailsEntities.spliterator().estimateSize());
+        final HearingDayDetailsEntity hearingDayDetailsEntity = hearingDayDetailsEntities.iterator().next();
+
+        assertEquals(parse("2022-02-10T10:30:00"), hearingDayDetailsEntity.getStartDateTime());
+        assertEquals(parse("2022-02-10T16:30:00"), hearingDayDetailsEntity.getEndDateTime());
+    }
+
+    @Test
+    @Sql(scripts = {DELETE_HEARING_DATA_SCRIPT, GET_HEARINGS_DATA_SCRIPT})
+    void shouldInitiateRequest_shouldStoreSingleHearingSessionPerDay() throws JsonProcessingException {
+        JsonNode hearingSessionsJsonNode = OBJECT_MAPPER.readTree(String.format(HEARING, 1,
+                createHearingSessions(
+                        List.of("2022-02-10T10:30:00", "2022-02-11T12:00:00"),
+                        List.of("2022-02-10T11:30:00", "2022-02-11T12:30:00"))
+        ));
+
+        final var februaryTenth =
+                new ImmutablePair<>(parse("2022-02-10T10:30:00"), parse("2022-02-10T11:30:00"));
+        final var februaryEleventh =
+                new ImmutablePair<>(parse("2022-02-11T12:00:00"), parse("2022-02-11T12:30:00"));
+
+        initiateRequest(hearingSessionsJsonNode);
+
+        assertHearingDayDetails(List.of(februaryTenth, februaryEleventh));
+    }
+
+    @Test
+    @Sql(scripts = {DELETE_HEARING_DATA_SCRIPT, GET_HEARINGS_DATA_SCRIPT})
+    void shouldInitiateRequest_shouldStoreSingleHearingSessionForSameDateAndDifferentDates() throws Exception {
+
+        JsonNode hearingSessionsJsonNode = OBJECT_MAPPER.readTree(String.format(HEARING, 1,
+                createHearingSessions(
+                        List.of("2022-02-10T10:30:00", "2022-02-10T12:00:00", "2022-02-11T14:30:00"),
+                        List.of("2022-02-10T11:30:00", "2022-02-10T12:30:00", "2022-02-11T16:30:00"))
+        ));
+
+        final var februaryTenth =
+                new ImmutablePair<>(parse("2022-02-10T10:30:00"), parse("2022-02-10T12:30:00"));
+        final var februaryEleventh =
+                new ImmutablePair<>(parse("2022-02-11T14:30:00"), parse("2022-02-11T16:30:00"));
+
+        initiateRequest(hearingSessionsJsonNode);
+
+        assertHearingDayDetails(List.of(februaryTenth, februaryEleventh));
+    }
+
+    private void assertHearingDayDetails(List<ImmutablePair<LocalDateTime, LocalDateTime>> expectedPairs) {
+        final Spliterator<HearingDayDetailsEntity> hearingDayDetailsEntities =
+                hearingDayDetailsRepository.findAll().spliterator();
+
+        assertEquals(expectedPairs.size(), hearingDayDetailsEntities.estimateSize());
+
+        final List<ImmutablePair<LocalDateTime, LocalDateTime>> hearingSessionStartAndEndTimes =
+                stream(hearingDayDetailsEntities, false)
+                        .map(hearingDayDetailsEntity ->
+                                ImmutablePair.of(hearingDayDetailsEntity.getStartDateTime(),
+                                        hearingDayDetailsEntity.getEndDateTime()))
+                        .collect(Collectors.toUnmodifiableList());
+
+        assertTrue(hearingSessionStartAndEndTimes.containsAll(expectedPairs));
     }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/reform/hmc/config/MessageProcessorIT.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/hmc/config/MessageProcessorIT.java
@@ -24,7 +24,6 @@ import uk.gov.hmcts.reform.hmc.repository.HearingDayDetailsRepository;
 import uk.gov.hmcts.reform.hmc.service.InboundQueueService;
 import uk.gov.hmcts.reform.hmc.service.InboundQueueServiceImpl;
 
-import javax.inject.Inject;
 import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.List;
@@ -32,6 +31,7 @@ import java.util.Map;
 import java.util.Spliterator;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import javax.inject.Inject;
 
 import static java.time.LocalDateTime.parse;
 import static java.util.stream.StreamSupport.stream;

--- a/src/integrationTest/java/uk/gov/hmcts/reform/hmc/repository/HearingDayDetailsRepository.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/hmc/repository/HearingDayDetailsRepository.java
@@ -1,0 +1,13 @@
+package uk.gov.hmcts.reform.hmc.repository;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import uk.gov.hmcts.reform.hmc.data.HearingDayDetailsEntity;
+
+@Transactional(propagation = Propagation.REQUIRES_NEW)
+@Repository
+public interface HearingDayDetailsRepository extends CrudRepository<HearingDayDetailsEntity, Long> {
+
+}

--- a/src/main/java/uk/gov/hmcts/reform/hmc/helper/hmi/HmiHearingResponseMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/hmc/helper/hmi/HmiHearingResponseMapper.java
@@ -1,7 +1,5 @@
 package uk.gov.hmcts.reform.hmc.helper.hmi;
 
-import org.apache.commons.collections4.MultiValuedMap;
-import org.apache.commons.collections4.multimap.ArrayListValuedHashMap;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.hmc.client.hmi.ErrorDetails;
 import uk.gov.hmcts.reform.hmc.client.hmi.HearingAttendee;
@@ -25,12 +23,13 @@ import uk.gov.hmcts.reform.hmc.model.HmcHearingUpdate;
 
 import java.time.Clock;
 import java.time.LocalDateTime;
-import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
+import static java.time.temporal.ChronoUnit.DAYS;
 import static uk.gov.hmcts.reform.hmc.domain.model.enums.HearingStatus.AWAITING_LISTING;
 import static uk.gov.hmcts.reform.hmc.domain.model.enums.HearingStatus.CANCELLATION_SUBMITTED;
 import static uk.gov.hmcts.reform.hmc.domain.model.enums.HearingStatus.EXCEPTION;
@@ -86,10 +85,11 @@ public class HmiHearingResponseMapper {
     }
 
     private List<HearingSession> findUniqueHearingSessionsPerDay(List<HearingSession> hearingSessions) {
-        MultiValuedMap<LocalDateTime, HearingSession> uniqueDays = new ArrayListValuedHashMap<>();
 
-        hearingSessions.stream().forEach(hearingSession ->
-                uniqueDays.put(hearingSession.getHearingStartTime().truncatedTo(ChronoUnit.DAYS), hearingSession));
+        final Map<LocalDateTime, List<HearingSession>> uniqueDays = hearingSessions.stream()
+                .collect(
+                        Collectors.groupingBy(hearingSession ->
+                                hearingSession.getHearingStartTime().truncatedTo(DAYS)));
 
         return uniqueDays.keySet().stream().map(date -> {
             HearingSession hearingSessionWithEarliestStartTime =

--- a/src/test/java/uk/gov/hmcts/reform/hmc/helper/HmiHearingResponseMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/hmc/helper/HmiHearingResponseMapperTest.java
@@ -5,6 +5,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.MockitoAnnotations;
 import uk.gov.hmcts.reform.hmc.client.hmi.ErrorDetails;
 import uk.gov.hmcts.reform.hmc.client.hmi.Hearing;
@@ -33,9 +36,15 @@ import uk.gov.hmcts.reform.hmc.model.HmcHearingResponse;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
+import static java.time.LocalDateTime.of;
+import static java.time.LocalDateTime.parse;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -52,7 +61,7 @@ import static uk.gov.hmcts.reform.hmc.domain.model.enums.HearingStatus.UPDATE_SU
 class HmiHearingResponseMapperTest {
 
 
-    private HmiHearingResponseMapper hmiHearingResponseMapper;
+    private static HmiHearingResponseMapper hmiHearingResponseMapper;
 
     @BeforeEach
     public void setUp() {
@@ -87,7 +96,7 @@ class HmiHearingResponseMapperTest {
             ),
             () -> assertThat(
                 response.getHearingResponses().get(1).getRequestTimeStamp(),
-                is(LocalDateTime.parse("2021-08-10T12:20:00"))
+                is(parse("2021-08-10T12:20:00"))
             ),
             () -> assertThat(response.getHearingResponses().get(1).getRequestVersion(), is(1)),
             () -> assertThat(response.getHearingResponses().get(1).getListingStatus(), is(ListingStatus.DRAFT.name())),
@@ -96,11 +105,11 @@ class HmiHearingResponseMapperTest {
             () -> assertThat(response.getHearingResponses().get(1).getListingCaseStatus(), is(EXCEPTION.name())),
             () -> assertThat(
                 response.getHearingResponses().get(1).getHearingDayDetails().get(0).getStartDateTime(),
-                is(LocalDateTime.parse("2021-08-10T12:20:00"))
+                is(parse("2021-08-10T12:20:00"))
             ),
             () -> assertThat(
                 response.getHearingResponses().get(1).getHearingDayDetails().get(0).getEndDateTime(),
-                is(LocalDateTime.parse("2021-08-10T12:20:00"))
+                is(parse("2021-08-10T12:20:00"))
             ),
             () -> assertThat(
                 response.getHearingResponses().get(1).getHearingDayDetails().get(0).getRoomId(),
@@ -135,7 +144,7 @@ class HmiHearingResponseMapperTest {
             ),
             () -> assertThat(
                 response.getHearingResponses().get(1).getRequestTimeStamp(),
-                is(LocalDateTime.parse("2021-08-10T12:20:00"))
+                is(parse("2021-08-10T12:20:00"))
             ),
             () -> assertThat(response.getHearingResponses().get(1).getRequestVersion(), is(1)),
             () -> assertThat(response.getHearingResponses().get(1).getListingStatus(), is(ListingStatus.DRAFT.name())),
@@ -144,11 +153,11 @@ class HmiHearingResponseMapperTest {
             () -> assertThat(response.getHearingResponses().get(1).getListingCaseStatus(), is(EXCEPTION.name())),
             () -> assertThat(
                 response.getHearingResponses().get(1).getHearingDayDetails().get(0).getStartDateTime(),
-                is(LocalDateTime.parse("2021-10-11T12:20:00"))
+                is(parse("2021-10-11T12:20:00"))
             ),
             () -> assertThat(
                 response.getHearingResponses().get(1).getHearingDayDetails().get(0).getEndDateTime(),
-                is(LocalDateTime.parse("2021-10-12T12:20:00"))
+                is(parse("2021-10-12T12:20:00"))
             ),
             () -> assertThat(
                 response.getHearingResponses().get(1).getHearingDayDetails().get(0).getRoomId(),
@@ -183,7 +192,7 @@ class HmiHearingResponseMapperTest {
             ),
             () -> assertThat(
                 response.getHearingResponses().get(1).getRequestTimeStamp(),
-                is(LocalDateTime.parse("2021-08-10T12:20:00"))
+                is(parse("2021-08-10T12:20:00"))
             ),
             () -> assertThat(response.getHearingResponses().get(1).getRequestVersion(), is(1)),
             () -> assertThat(response.getHearingResponses().get(1).getListingStatus(), is(ListingStatus.DRAFT.name())),
@@ -192,11 +201,11 @@ class HmiHearingResponseMapperTest {
             () -> assertThat(response.getHearingResponses().get(1).getListingCaseStatus(), is(EXCEPTION.name())),
             () -> assertThat(
                 response.getHearingResponses().get(1).getHearingDayDetails().get(0).getStartDateTime(),
-                is(LocalDateTime.parse("2021-10-11T12:20:00"))
+                is(parse("2021-10-11T12:20:00"))
             ),
             () -> assertThat(
                 response.getHearingResponses().get(1).getHearingDayDetails().get(0).getEndDateTime(),
-                is(LocalDateTime.parse("2021-10-12T12:20:00"))
+                is(parse("2021-10-12T12:20:00"))
             ),
             () -> assertThat(
                 response.getHearingResponses().get(1).getHearingDayDetails().get(0).getRoomId(),
@@ -213,32 +222,137 @@ class HmiHearingResponseMapperTest {
             () -> assertThat(response.getHearingResponses().get(1).getHearingDayDetails().get(0)
                                  .getHearingDayPanel().get(0).getPanelUserId(), is("JohCode")),
             () -> assertThat(response.getHearingResponses().get(1).getHearingDayDetails().get(0)
-                                 .getHearingDayPanel().get(0).getIsPresiding(), is(true)),
-
-            () -> assertThat(
-                response.getHearingResponses().get(1).getHearingDayDetails().get(1).getStartDateTime(),
-                is(LocalDateTime.parse("2021-10-11T12:20:00"))
-            ),
-            () -> assertThat(
-                response.getHearingResponses().get(1).getHearingDayDetails().get(1).getEndDateTime(),
-                is(LocalDateTime.parse("2021-10-12T12:20:00"))
-            ),
-            () -> assertThat(
-                response.getHearingResponses().get(1).getHearingDayDetails().get(1).getRoomId(),
-                is("multiDayRoomName")
-            ),
-            () -> assertNull(response.getHearingResponses().get(1).getHearingDayDetails().get(1).getVenueId()),
-            () -> assertThat(response.getHearingResponses().get(1).getHearingDayDetails().get(1)
-                                 .getHearingAttendeeDetails().get(0).getPartyId(), is("entityId")),
-            () -> assertThat(
-                response.getHearingResponses().get(1).getHearingDayDetails().get(1)
-                    .getHearingAttendeeDetails().get(0).getPartySubChannelType(),
-                is("codeSubChannel")
-            ),
-            () -> assertThat(response.getHearingResponses().get(1).getHearingDayDetails().get(1)
-                                 .getHearingDayPanel().get(0).getPanelUserId(), is("JohCode")),
-            () -> assertThat(response.getHearingResponses().get(1).getHearingDayDetails().get(1)
                                  .getHearingDayPanel().get(0).getIsPresiding(), is(true)));
+    }
+
+    private static HearingSession createHearingSession(LocalDateTime startDateTime, LocalDateTime endDateTime) {
+        final HearingSession hearingSession = new HearingSession();
+        hearingSession.setHearingStartTime(startDateTime);
+        hearingSession.setHearingEndTime(endDateTime);
+
+        return hearingSession;
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideMultipleHearingSessions")
+    void mapHmiMultiSessionMultiDayHearingToEntitySingleHearingSessionPerDay(List<LocalDateTime> startTimes,
+                                                                             List<LocalDateTime> endTimes,
+                                                                             List<HearingSession> expectedSessions) {
+        assertEquals(startTimes.size(), endTimes.size());
+
+        final HearingResponse hearingResponse = generateHmiMultiSessionMultiDayHearing(
+                "random", HearingCode.EXCEPTION, 1, ListingStatus.DRAFT, startTimes.size());
+
+        final List<HearingSession> existingSessions = hearingResponse.getHearing().getHearingSessions();
+
+        for (int i = 0; i < existingSessions.size(); i++) {
+            HearingSession hearingSession = existingSessions.get(i);
+            hearingSession.setHearingStartTime(startTimes.get(i));
+            hearingSession.setHearingEndTime(endTimes.get(i));
+        }
+
+        HearingEntity response = hmiHearingResponseMapper.mapHmiHearingToEntity(hearingResponse,
+                generateHearingEntity("AWAITING_LISTING", 1)
+        );
+        assertAll(
+                () -> assertThat(response.getHearingResponses().size(), is(2)),
+                () -> assertThat(
+                        response.getHearingResponses().get(1).getListingTransactionId(),
+                        is("transactionIdCaseHQ")
+                ),
+                () -> assertThat(
+                        response.getHearingResponses().get(1).getRequestTimeStamp(),
+                        is(parse("2021-08-10T12:20:00"))
+                ),
+                () -> assertThat(response.getHearingResponses().get(1).getRequestVersion(), is(1)),
+                () -> assertThat(response.getHearingResponses().get(1).getListingStatus(),
+                        is(ListingStatus.DRAFT.name())),
+                () -> assertThat(response.getHearingResponses().get(1).getCancellationReasonType(), is("reason")),
+                () -> assertThat(response.getHearingResponses().get(1).getTranslatorRequired(), is(true)),
+                () -> assertThat(response.getHearingResponses().get(1).getListingCaseStatus(), is(EXCEPTION.name())),
+                () -> assertThat(
+                        response.getHearingResponses().get(1).getHearingDayDetails().size(),
+                        is(expectedSessions.size())
+                ),
+                () -> assertHearingDayDetails(response.getHearingResponses().get(1), expectedSessions)
+        );
+    }
+
+    private static Stream<Arguments> provideMultipleHearingSessions() {
+
+        return Stream.of(
+                // a hearing session with same date
+                Arguments.of(
+                        List.of(parse("2022-01-05T09:45:02"),
+                                parse("2022-01-05T09:45:01"),
+                                parse("2022-01-05T10:46:03")
+                        ),
+                        List.of(parse("2022-01-05T13:30:01"),
+                                parse("2022-01-05T13:50:30"),
+                                parse("2022-01-05T13:29:59")
+                        ),
+                        List.of(
+                                createHearingSession(parse("2022-01-05T09:45:01"), parse("2022-01-05T13:50:30"))
+                        )
+                ),
+                // a hearing session with different date
+                Arguments.of(
+                        List.of(parse("2022-05-16T10:45:09"),
+                                parse("2022-05-16T11:39:10")
+                        ),
+                        List.of(parse("2022-05-16T15:37:16"),
+                                parse("2022-05-16T17:09:53")
+                        ),
+                        List.of(
+                                createHearingSession(parse("2022-05-16T10:45:09"), parse("2022-05-16T17:09:53"))
+                        )
+                ),
+                // hearing session with same date and different dates
+                Arguments.of(
+                        List.of(parse("2022-02-10T10:30:00"),
+                                parse("2022-02-10T12:00:00"),
+                                parse("2022-02-10T14:30:00"),
+                                parse("2022-02-11T10:35:00"),
+                                parse("2022-02-11T12:40:00"),
+                                parse("2022-02-12T14:50:00")
+                        ),
+
+                        List.of(parse("2022-02-10T10:30:00"),
+                                parse("2022-02-10T12:00:00"),
+                                parse("2022-02-10T14:30:00"),
+                                parse("2022-02-11T10:36:00"),
+                                parse("2022-02-11T12:40:00"),
+                                parse("2022-02-12T16:57:00")
+                        ),
+
+                        List.of(
+                                createHearingSession(parse("2022-02-10T10:30:00"), parse("2022-02-10T14:30:00")),
+                                createHearingSession(parse("2022-02-11T10:35:00"), parse("2022-02-11T12:40:00")),
+                                createHearingSession(parse("2022-02-12T14:50:00"), parse("2022-02-12T16:57:00"))
+                        )
+                )
+        );
+    }
+
+    private static void assertHearingDayDetails(HearingResponseEntity hearingResponseEntity,
+                                                List<HearingSession> hearingSessions) {
+
+        hearingResponseEntity.getHearingDayDetails().forEach(hearingDayDetailsEntity -> {
+                assertThat(hearingSessions.stream()
+                        .anyMatch(hearingSession ->
+                                hearingSession.getHearingStartTime().equals(hearingDayDetailsEntity.getStartDateTime())
+                                && hearingSession.getHearingEndTime().equals(hearingDayDetailsEntity.getEndDateTime())),
+                                    is(true));
+
+                assertThat(hearingDayDetailsEntity.getRoomId(), is("multiDayRoomName"));
+                assertThat(hearingDayDetailsEntity.getVenueId(), is(nullValue()));
+                assertThat(hearingDayDetailsEntity.getHearingAttendeeDetails().get(0).getPartyId(), is("entityId"));
+                assertThat(hearingDayDetailsEntity.getHearingAttendeeDetails().get(0).getPartySubChannelType(),
+                        is("codeSubChannel"));
+                assertThat(hearingDayDetailsEntity.getHearingDayPanel().get(0).getPanelUserId(), is("JohCode"));
+                assertThat(hearingDayDetailsEntity.getHearingDayPanel().get(0).getIsPresiding(), is(true));
+            }
+        );
     }
 
     @Test
@@ -255,7 +369,7 @@ class HmiHearingResponseMapperTest {
             ),
             () -> assertThat(
                 response.getHearingResponses().get(1).getRequestTimeStamp(),
-                is(LocalDateTime.parse("2021-08-10T12:20:00"))
+                is(parse("2021-08-10T12:20:00"))
             ),
             () -> assertThat(response.getHearingResponses().get(1).getRequestVersion(), is(1)),
             () -> assertThat(response.getHearingResponses().get(1).getListingStatus(), is(ListingStatus.DRAFT.name())),
@@ -264,11 +378,11 @@ class HmiHearingResponseMapperTest {
             () -> assertThat(response.getHearingResponses().get(1).getListingCaseStatus(), is(EXCEPTION.name())),
             () -> assertThat(
                 response.getHearingResponses().get(1).getHearingDayDetails().get(0).getStartDateTime(),
-                is(LocalDateTime.parse("2021-08-10T12:20:00"))
+                is(parse("2021-08-10T12:20:00"))
             ),
             () -> assertThat(
                 response.getHearingResponses().get(1).getHearingDayDetails().get(0).getEndDateTime(),
-                is(LocalDateTime.parse("2021-08-10T12:20:00"))
+                is(parse("2021-08-10T12:20:00"))
             ),
             () -> assertThat(
                 response.getHearingResponses().get(1).getHearingDayDetails().get(0).getRoomId(),
@@ -426,20 +540,20 @@ class HmiHearingResponseMapperTest {
     void mapHmiHearingToEntityToHmcModel() {
         HmcHearingResponse response = hmiHearingResponseMapper.mapEntityToHmcModel(
             generateHearingResponseEntity(1,
-                                          LocalDateTime.of(2019, 1, 10, 11, 20, 00),
+                                          of(2019, 1, 10, 11, 20, 00),
                                           ListingStatus.DRAFT.name(),
-                                          LocalDateTime.of(2019, 1, 10, 11, 20, 00),
+                                          of(2019, 1, 10, 11, 20, 00),
                                           "12", true, "11", HearingCode.LISTED.name()),
             generateHearingEntity("AWAITING_LISTING", 1, 1L)
         );
         assertAll(
             () -> assertThat(response.getHearingID(), is("1")),
             () -> assertThat(response.getHearingUpdate().getHearingResponseReceivedDateTime(),
-                             is(LocalDateTime.parse("2019-01-10T11:20"))),
+                             is(parse("2019-01-10T11:20"))),
             () -> assertThat(response.getHearingUpdate().getHmcStatus(), is("AWAITING_LISTING")),
             () -> assertThat(response.getHearingUpdate().getHearingListingStatus(), is(ListingStatus.DRAFT)),
             () -> assertThat(response.getHearingUpdate().getNextHearingDate(),
-                             is(LocalDateTime.parse("2019-01-10T11:20"))),
+                             is(parse("2019-01-10T11:20"))),
             () -> assertThat(response.getHearingUpdate().getHearingVenueId(), is("12")),
             () -> assertThat(response.getHearingUpdate().getHearingJudgeId(), is("11")),
             () -> assertThat(response.getHearingUpdate().getListAssistCaseStatus(), is(HearingCode.LISTED.name()))
@@ -624,8 +738,8 @@ class HmiHearingResponseMapperTest {
         Hearing hearing = new Hearing();
         hearing.setHearingCaseVersionId(version);
         hearing.setHearingCancellationReason("reason");
-        hearing.setHearingStartTime(LocalDateTime.parse("2021-08-10T12:20:00"));
-        hearing.setHearingEndTime(LocalDateTime.parse("2021-08-10T12:20:00"));
+        hearing.setHearingStartTime(parse("2021-08-10T12:20:00"));
+        hearing.setHearingEndTime(parse("2021-08-10T12:20:00"));
         hearing.setHearingTranslatorRequired(true);
 
         HearingStatus hearingStatus = new HearingStatus();
@@ -668,15 +782,15 @@ class HmiHearingResponseMapperTest {
         HearingResponse hearingResponse = new HearingResponse();
 
         MetaResponse metaResponse = new MetaResponse();
-        metaResponse.setTimestamp(LocalDateTime.parse("2021-08-10T12:20:00"));
+        metaResponse.setTimestamp(parse("2021-08-10T12:20:00"));
         metaResponse.setTransactionIdCaseHQ("transactionIdCaseHQ");
         hearingResponse.setMeta(metaResponse);
 
         Hearing hearing = new Hearing();
         hearing.setHearingCaseVersionId(version);
         hearing.setHearingCancellationReason("reason");
-        hearing.setHearingStartTime(LocalDateTime.parse("2021-08-10T12:20:00"));
-        hearing.setHearingEndTime(LocalDateTime.parse("2021-08-10T12:20:00"));
+        hearing.setHearingStartTime(parse("2021-08-10T12:20:00"));
+        hearing.setHearingEndTime(parse("2021-08-10T12:20:00"));
         hearing.setHearingTranslatorRequired(true);
 
         uk.gov.hmcts.reform.hmc.client.hmi.HearingStatus hearingStatus =
@@ -721,26 +835,27 @@ class HmiHearingResponseMapperTest {
         return hearingResponse;
     }
 
-    private HearingResponse generateHmiMultiSessionMultiDayHearing(String key,
-                                                       HearingCode hearingCode,
-                                                       int version,
-                                                       ListingStatus status) {
+    private static HearingResponse generateHmiMultiSessionMultiDayHearing(String key,
+                                                                   HearingCode hearingCode,
+                                                                   int version,
+                                                                   ListingStatus status,
+                                                                   int numHearingSessions) {
         HearingResponse hearingResponse = new HearingResponse();
 
         MetaResponse metaResponse = new MetaResponse();
-        metaResponse.setTimestamp(LocalDateTime.parse("2021-08-10T12:20:00"));
+        metaResponse.setTimestamp(parse("2021-08-10T12:20:00"));
         metaResponse.setTransactionIdCaseHQ("transactionIdCaseHQ");
         hearingResponse.setMeta(metaResponse);
 
         Hearing hearing = new Hearing();
         hearing.setHearingCaseVersionId(version);
         hearing.setHearingCancellationReason("reason");
-        hearing.setHearingStartTime(LocalDateTime.parse("2021-08-10T12:20:00"));
-        hearing.setHearingEndTime(LocalDateTime.parse("2021-08-10T12:20:00"));
+        hearing.setHearingStartTime(parse("2021-08-10T12:20:00"));
+        hearing.setHearingEndTime(parse("2021-08-10T12:20:00"));
         hearing.setHearingTranslatorRequired(true);
 
         uk.gov.hmcts.reform.hmc.client.hmi.HearingStatus hearingStatus =
-            new uk.gov.hmcts.reform.hmc.client.hmi.HearingStatus();
+                new uk.gov.hmcts.reform.hmc.client.hmi.HearingStatus();
         hearingStatus.setCode(status);
         hearing.setHearingStatus(hearingStatus);
 
@@ -771,27 +886,33 @@ class HmiHearingResponseMapperTest {
         hearingJoh.setIsPresiding(true);
         hearing.setHearingJohs(new ArrayList<>(List.of(hearingJoh)));
 
-        HearingSession hearingSession = generateHearingSession(hearingRoom,
-                                                               hearingVenue,
-                                                               List.of(hearingAttendee),
-                                                               List.of(hearingJoh));
-        HearingSession hearingSession1 = generateHearingSession(hearingRoom,
-                                                               hearingVenue,
-                                                               List.of(hearingAttendee),
-                                                               List.of(hearingJoh));
-        hearing.setHearingSessions(List.of(hearingSession, hearingSession1));
+        final List<HearingSession> hearingSessions =
+                IntStream.range(0, numHearingSessions).mapToObj(i -> generateHearingSession(hearingRoom,
+                hearingVenue,
+                List.of(hearingAttendee),
+                List.of(hearingJoh)))
+                .collect(Collectors.toList());
+
+        hearing.setHearingSessions(hearingSessions);
 
         hearingResponse.setHearing(hearing);
         return hearingResponse;
     }
 
-    private HearingSession generateHearingSession(HearingRoom hearingRoom,
+    private HearingResponse generateHmiMultiSessionMultiDayHearing(String key,
+                                                       HearingCode hearingCode,
+                                                       int version,
+                                                       ListingStatus status) {
+        return generateHmiMultiSessionMultiDayHearing(key, hearingCode, version, status, 2);
+    }
+
+    private static HearingSession generateHearingSession(HearingRoom hearingRoom,
                                                   HearingVenue hearingVenue,
                                                   List<HearingAttendee> hearingAttendees,
                                                   List<HearingJoh> hearingJohs) {
         HearingSession hearingSession = new HearingSession();
-        hearingSession.setHearingStartTime(LocalDateTime.parse("2021-10-11T12:20:00"));
-        hearingSession.setHearingEndTime(LocalDateTime.parse("2021-10-12T12:20:00"));
+        hearingSession.setHearingStartTime(parse("2021-10-11T12:20:00"));
+        hearingSession.setHearingEndTime(parse("2021-10-12T12:20:00"));
         hearingSession.setHearingRoom(hearingRoom);
         hearingSession.setHearingVenue(hearingVenue);
         hearingSession.setHearingAttendees(hearingAttendees);
@@ -817,7 +938,7 @@ class HmiHearingResponseMapperTest {
 
     private MetaResponse generateMetaResponse() {
         MetaResponse metaResponse = new MetaResponse();
-        metaResponse.setTimestamp(LocalDateTime.parse("2021-08-10T12:20:00"));
+        metaResponse.setTimestamp(parse("2021-08-10T12:20:00"));
         metaResponse.setTransactionIdCaseHQ("transactionIdCaseHQ");
         return metaResponse;
     }
@@ -828,7 +949,7 @@ class HmiHearingResponseMapperTest {
         return  hearingCaseStatus;
     }
 
-    private HearingEntity generateHearingEntity(String status, int version) {
+    private static HearingEntity generateHearingEntity(String status, int version) {
         HearingEntity hearingEntity = new HearingEntity();
         CaseHearingRequestEntity caseHearingRequestEntity = new CaseHearingRequestEntity();
         caseHearingRequestEntity.setVersionNumber(version);


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/HMAN-215

### Change description ###

Currently, we process the hearingSessions element such that every hearingSession array item will be inserted into the hearing_day_details table . 

This needs to be updated to allow only one single record for each day with earliest hearingStartTime on the day as the hearingStartTime and last hearingEndTime on the day as the hearingEndTime for the day.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
