### PR TITLE
HMAN-307- add and use new change_reasons db table

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/hmc/RestExceptionHandlerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/hmc/RestExceptionHandlerTest.java
@@ -101,6 +101,7 @@ public class RestExceptionHandlerTest extends BaseTest {
         hearingLocations.add(location1);
         hearingDetails.setHearingLocations(hearingLocations);
         hearingDetails.setHearingChannels(List.of(""));
+        hearingDetails.setAmendReasonCodes(List.of("reason"));
         CaseDetails caseDetails = new CaseDetails();
         caseDetails.setHmctsServiceCode("ABA1");
         caseDetails.setCaseRef("1111222233334444");

--- a/src/integrationTest/java/uk/gov/hmcts/reform/hmc/controllers/HearingManagementControllerIT.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/hmc/controllers/HearingManagementControllerIT.java
@@ -15,6 +15,7 @@ import uk.gov.hmcts.reform.hmc.ApplicationParams;
 import uk.gov.hmcts.reform.hmc.BaseTest;
 import uk.gov.hmcts.reform.hmc.client.datastore.model.DataStoreCaseDetails;
 import uk.gov.hmcts.reform.hmc.config.MessageReaderFromQueueConfiguration;
+import uk.gov.hmcts.reform.hmc.data.ChangeReasonsEntity;
 import uk.gov.hmcts.reform.hmc.data.RoleAssignmentAttributesResource;
 import uk.gov.hmcts.reform.hmc.data.RoleAssignmentResource;
 import uk.gov.hmcts.reform.hmc.data.RoleAssignmentResponse;
@@ -35,6 +36,7 @@ import uk.gov.hmcts.reform.hmc.model.RequestDetails;
 import uk.gov.hmcts.reform.hmc.model.UnavailabilityDow;
 import uk.gov.hmcts.reform.hmc.model.UnavailabilityRanges;
 import uk.gov.hmcts.reform.hmc.model.UpdateHearingRequest;
+import uk.gov.hmcts.reform.hmc.repository.ChangeReasonsRepository;
 import uk.gov.hmcts.reform.hmc.utils.TestingUtil;
 
 import java.time.LocalDate;
@@ -44,6 +46,9 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.Spliterator;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.okJson;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
@@ -51,6 +56,9 @@ import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.Matchers.hasSize;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -111,6 +119,7 @@ import static uk.gov.hmcts.reform.hmc.exceptions.ValidationError.HMCTS_INTERNAL_
 import static uk.gov.hmcts.reform.hmc.exceptions.ValidationError.HMCTS_INTERNAL_CASE_NAME_MAX_LENGTH;
 import static uk.gov.hmcts.reform.hmc.exceptions.ValidationError.HMCTS_SERVICE_CODE_EMPTY_INVALID;
 import static uk.gov.hmcts.reform.hmc.exceptions.ValidationError.INTERPRETER_LANGUAGE_MAX_LENGTH;
+import static uk.gov.hmcts.reform.hmc.exceptions.ValidationError.INVALID_AMEND_REASON_CODE;
 import static uk.gov.hmcts.reform.hmc.exceptions.ValidationError.INVALID_CASE_CATEGORIES;
 import static uk.gov.hmcts.reform.hmc.exceptions.ValidationError.INVALID_CASE_DETAILS;
 import static uk.gov.hmcts.reform.hmc.exceptions.ValidationError.INVALID_DELETE_HEARING_STATUS;
@@ -179,6 +188,9 @@ class HearingManagementControllerIT extends BaseTest {
 
     @Autowired
     private ApplicationParams applicationParams;
+
+    @Autowired
+    private ChangeReasonsRepository changeReasonsRepository;
 
     private static final String url = "/hearing";
     public static final String USER_ID = "e8275d41-7f22-4ee7-8ed3-14644d6db096";
@@ -746,6 +758,7 @@ class HearingManagementControllerIT extends BaseTest {
             .andExpect(jsonPath("$.hearingRequestID").value("2000000000"))
             .andExpect(jsonPath("$.timeStamp").value(IsNull.notNullValue()))
             .andReturn();
+        assertChangeReasons();
     }
 
     @Test
@@ -766,6 +779,34 @@ class HearingManagementControllerIT extends BaseTest {
                             .content(objectMapper.writeValueAsString(hearingRequest)))
             .andExpect(status().is(201))
             .andReturn();
+        assertChangeReasons();
+    }
+
+    @Test
+    @Sql(scripts = {DELETE_HEARING_DATA_SCRIPT, INSERT_CASE_HEARING_DATA_SCRIPT})
+    void shouldReturn400_WhenUpdateHearingRequestHasNoAmendReasonCodes() throws Exception {
+        UpdateHearingRequest updateHearingRequest = new UpdateHearingRequest();
+        updateHearingRequest.setHearingDetails(TestingUtil.hearingDetails());
+        updateHearingRequest.getHearingDetails().setPanelRequirements(TestingUtil.panelRequirements());
+        updateHearingRequest.getHearingDetails().setAmendReasonCodes(Collections.emptyList());
+        updateHearingRequest.setCaseDetails(TestingUtil.caseDetails());
+        stubReturn400WhileValidateHearingObject(updateHearingRequest);
+        mockMvc.perform(put(url + "/2000000000")
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .content(objectMapper.writeValueAsString(updateHearingRequest)))
+                .andExpect(status().is(400))
+                .andExpect(jsonPath("$.errors", hasItem(INVALID_AMEND_REASON_CODE)))
+                .andReturn();
+
+        assertFalse(changeReasonsRepository.findAll().iterator().hasNext());
+    }
+
+    private void assertChangeReasons() {
+        final Spliterator<ChangeReasonsEntity> spliterator = changeReasonsRepository.findAll().spliterator();
+        assertEquals(2, spliterator.estimateSize());
+        assertTrue(StreamSupport.stream(spliterator, false)
+                .map(ChangeReasonsEntity::getChangeReasonType).collect(Collectors.toList())
+                .containsAll(List.of("reason 1", "reason 2")));
     }
 
     @Test
@@ -867,12 +908,13 @@ class HearingManagementControllerIT extends BaseTest {
                             .contentType(MediaType.APPLICATION_JSON_VALUE)
                             .content(objectMapper.writeValueAsString(hearingRequest)))
             .andExpect(status().is(400))
-            .andExpect(jsonPath("$.errors", hasSize(9)))
+            .andExpect(jsonPath("$.errors", hasSize(10)))
             .andExpect(jsonPath("$.errors", hasItems(AUTO_LIST_FLAG_NULL_EMPTY, HEARING_TYPE_NULL_EMPTY,
                                                      HEARING_WINDOW_NULL, DURATION_EMPTY, HEARING_PRIORITY_TYPE,
                                                      HEARING_LOCATION_EMPTY, INVALID_HEARING_LOCATION,
                                                      INVALID_PANEL_REQUIREMENTS,
-                                                     HEARING_CHANNEL_EMPTY
+                                                     HEARING_CHANNEL_EMPTY,
+                                                     INVALID_AMEND_REASON_CODE
             )))
             .andReturn();
     }
@@ -883,7 +925,7 @@ class HearingManagementControllerIT extends BaseTest {
         UpdateHearingRequest hearingRequest = TestingUtil.updateHearingRequest();
         hearingRequest.getHearingDetails().setHearingType("a".repeat(41));
         hearingRequest.getHearingDetails().setDuration(-1);
-        hearingRequest.getHearingDetails().setAmendReasonCode("a".repeat(71));
+        hearingRequest.getHearingDetails().setAmendReasonCodes(List.of("a".repeat(71)));
         List<String> nonStandardHearingDurationReasonsList = Collections.singletonList("a".repeat(71));
         hearingRequest.getHearingDetails().setNonStandardHearingDurationReasons(nonStandardHearingDurationReasonsList);
         hearingRequest.getHearingDetails().setHearingPriorityType("a".repeat(61));

--- a/src/integrationTest/java/uk/gov/hmcts/reform/hmc/service/HearingManagementServiceIT.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/hmc/service/HearingManagementServiceIT.java
@@ -24,7 +24,6 @@ import uk.gov.hmcts.reform.hmc.model.UpdateHearingRequest;
 import uk.gov.hmcts.reform.hmc.repository.HearingRepository;
 import uk.gov.hmcts.reform.hmc.utils.TestingUtil;
 
-import java.util.Collections;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -36,7 +35,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static uk.gov.hmcts.reform.hmc.constants.Constants.CANCELLATION_REQUESTED;
 import static uk.gov.hmcts.reform.hmc.constants.Constants.POST_HEARING_STATUS;
 import static uk.gov.hmcts.reform.hmc.constants.Constants.VERSION_NUMBER_TO_INCREMENT;
-import static uk.gov.hmcts.reform.hmc.exceptions.ValidationError.INVALID_AMEND_REASON_CODE;
 import static uk.gov.hmcts.reform.hmc.exceptions.ValidationError.INVALID_DELETE_HEARING_STATUS;
 import static uk.gov.hmcts.reform.hmc.exceptions.ValidationError.INVALID_DURATION_DETAILS;
 import static uk.gov.hmcts.reform.hmc.exceptions.ValidationError.INVALID_PUT_HEARING_STATUS;

--- a/src/integrationTest/java/uk/gov/hmcts/reform/hmc/service/HearingManagementServiceIT.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/hmc/service/HearingManagementServiceIT.java
@@ -282,28 +282,6 @@ class HearingManagementServiceIT extends BaseTest {
     }
 
     @Test
-    @Sql(scripts = {DELETE_HEARING_DATA_SCRIPT, UPDATE_HEARINGS_DATA_SCRIPT})
-    void testUpdateHearingRequest_WhenAmendReasonIsEmpty() {
-        UpdateHearingRequest request = TestingUtil.updateHearingRequestWithCaseSubType(1);
-        request.getHearingDetails().setAmendReasonCodes(Collections.emptyList());
-        Exception exception = assertThrows(BadRequestException.class, () -> {
-            hearingManagementService.updateHearingRequest(2000000024L, request);
-        });
-        assertEquals(INVALID_AMEND_REASON_CODE, exception.getMessage());
-    }
-
-    @Test
-    @Sql(scripts = {DELETE_HEARING_DATA_SCRIPT, UPDATE_HEARINGS_DATA_SCRIPT})
-    void testUpdateHearingRequest_WhenAmendReasonIsNull() {
-        UpdateHearingRequest request = TestingUtil.updateHearingRequestWithCaseSubType(1);
-        request.getHearingDetails().setAmendReasonCodes(null);
-        Exception exception = assertThrows(BadRequestException.class, () -> {
-            hearingManagementService.updateHearingRequest(2000000024L, request);
-        });
-        assertEquals(INVALID_AMEND_REASON_CODE, exception.getMessage());
-    }
-
-    @Test
     @Sql(scripts = {DELETE_HEARING_DATA_SCRIPT, HEARING_COMPLETION_DATA_SCRIPT})
     void testUpdateHearingCompletion_WithValidData() {
         ResponseEntity responseEntity = hearingManagementService.hearingCompletion(2000000000L);

--- a/src/integrationTest/java/uk/gov/hmcts/reform/hmc/service/HearingManagementServiceIT.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/hmc/service/HearingManagementServiceIT.java
@@ -24,6 +24,9 @@ import uk.gov.hmcts.reform.hmc.model.UpdateHearingRequest;
 import uk.gov.hmcts.reform.hmc.repository.HearingRepository;
 import uk.gov.hmcts.reform.hmc.utils.TestingUtil;
 
+import java.util.Collections;
+import java.util.List;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -152,7 +155,7 @@ class HearingManagementServiceIT extends BaseTest {
     void testValidateHearingRequest_WhenAmendReasonCodeIsNotNull() {
         HearingRequest createHearingRequest = new HearingRequest();
         HearingDetails hearingDetails = TestingUtil.hearingDetails();
-        hearingDetails.setAmendReasonCode("Amend Reason");
+        hearingDetails.setAmendReasonCodes(List.of("Amend Reason", "Amend Reason 2"));
         createHearingRequest.setHearingDetails(hearingDetails);
         createHearingRequest.getHearingDetails().setPanelRequirements(TestingUtil.panelRequirements());
         createHearingRequest.setCaseDetails(TestingUtil.caseDetailsWithCaseSubType());
@@ -282,7 +285,7 @@ class HearingManagementServiceIT extends BaseTest {
     @Sql(scripts = {DELETE_HEARING_DATA_SCRIPT, UPDATE_HEARINGS_DATA_SCRIPT})
     void testUpdateHearingRequest_WhenAmendReasonIsEmpty() {
         UpdateHearingRequest request = TestingUtil.updateHearingRequestWithCaseSubType(1);
-        request.getHearingDetails().setAmendReasonCode("");
+        request.getHearingDetails().setAmendReasonCodes(Collections.emptyList());
         Exception exception = assertThrows(BadRequestException.class, () -> {
             hearingManagementService.updateHearingRequest(2000000024L, request);
         });
@@ -293,7 +296,7 @@ class HearingManagementServiceIT extends BaseTest {
     @Sql(scripts = {DELETE_HEARING_DATA_SCRIPT, UPDATE_HEARINGS_DATA_SCRIPT})
     void testUpdateHearingRequest_WhenAmendReasonIsNull() {
         UpdateHearingRequest request = TestingUtil.updateHearingRequestWithCaseSubType(1);
-        request.getHearingDetails().setAmendReasonCode(null);
+        request.getHearingDetails().setAmendReasonCodes(null);
         Exception exception = assertThrows(BadRequestException.class, () -> {
             hearingManagementService.updateHearingRequest(2000000024L, request);
         });

--- a/src/integrationTest/java/uk/gov/hmcts/reform/hmc/service/HearingManagementServiceIT.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/hmc/service/HearingManagementServiceIT.java
@@ -24,6 +24,7 @@ import uk.gov.hmcts.reform.hmc.model.UpdateHearingRequest;
 import uk.gov.hmcts.reform.hmc.repository.HearingRepository;
 import uk.gov.hmcts.reform.hmc.utils.TestingUtil;
 
+import java.util.Collections;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -35,6 +36,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static uk.gov.hmcts.reform.hmc.constants.Constants.CANCELLATION_REQUESTED;
 import static uk.gov.hmcts.reform.hmc.constants.Constants.POST_HEARING_STATUS;
 import static uk.gov.hmcts.reform.hmc.constants.Constants.VERSION_NUMBER_TO_INCREMENT;
+import static uk.gov.hmcts.reform.hmc.exceptions.ValidationError.INVALID_AMEND_REASON_CODE;
 import static uk.gov.hmcts.reform.hmc.exceptions.ValidationError.INVALID_DELETE_HEARING_STATUS;
 import static uk.gov.hmcts.reform.hmc.exceptions.ValidationError.INVALID_DURATION_DETAILS;
 import static uk.gov.hmcts.reform.hmc.exceptions.ValidationError.INVALID_PUT_HEARING_STATUS;
@@ -277,6 +279,28 @@ class HearingManagementServiceIT extends BaseTest {
         assertEquals(PutHearingStatus.UPDATE_REQUESTED.name(), response.getStatus());
         assertEquals(2, response.getVersionNumber());
         assertNotNull(response.getTimeStamp());
+    }
+
+    @Test
+    @Sql(scripts = {DELETE_HEARING_DATA_SCRIPT, UPDATE_HEARINGS_DATA_SCRIPT})
+    void testUpdateHearingRequest_WhenAmendReasonIsEmpty() {
+        UpdateHearingRequest request = TestingUtil.updateHearingRequestWithCaseSubType(1);
+        request.getHearingDetails().setAmendReasonCodes(Collections.emptyList());
+        Exception exception = assertThrows(BadRequestException.class, () -> {
+            hearingManagementService.updateHearingRequest(2000000024L, request);
+        });
+        assertEquals(INVALID_AMEND_REASON_CODE, exception.getMessage());
+    }
+
+    @Test
+    @Sql(scripts = {DELETE_HEARING_DATA_SCRIPT, UPDATE_HEARINGS_DATA_SCRIPT})
+    void testUpdateHearingRequest_WhenAmendReasonIsNull() {
+        UpdateHearingRequest request = TestingUtil.updateHearingRequestWithCaseSubType(1);
+        request.getHearingDetails().setAmendReasonCodes(null);
+        Exception exception = assertThrows(BadRequestException.class, () -> {
+            hearingManagementService.updateHearingRequest(2000000024L, request);
+        });
+        assertEquals(INVALID_AMEND_REASON_CODE, exception.getMessage());
     }
 
     @Test

--- a/src/integrationTest/resources/sql/delete-hearing-tables.sql
+++ b/src/integrationTest/resources/sql/delete-hearing-tables.sql
@@ -32,8 +32,11 @@ DELETE FROM actual_hearing_day;
 DELETE FROM actual_hearing;
 DELETE FROM hearing_response;
 DELETE FROM cancellation_reasons;
+DELETE FROM change_reasons;
 DELETE FROM case_hearing_request;
 DELETE FROM linked_hearing_details_audit;
 DELETE FROM linked_group_details_audit;
 DELETE FROM hearing;
 DELETE FROM linked_group_details;
+
+ALTER SEQUENCE public.case_hearing_id_seq RESTART WITH 1;

--- a/src/integrationTest/resources/sql/insert-case_hearing_request_change_reasons.sql
+++ b/src/integrationTest/resources/sql/insert-case_hearing_request_change_reasons.sql
@@ -1,0 +1,47 @@
+INSERT INTO hearing (hearing_id, status)
+VALUES ('2000000011', 'HEARING_AMENDED'),
+       ('2000000012', 'UPDATE_REQUESTED');
+
+INSERT INTO case_hearing_request (auto_list_flag,
+                                  hearing_type,
+                                  required_duration_in_minutes,
+                                  hearing_priority_type,
+                                  number_of_physical_attendees,
+                                  hearing_in_welsh_flag,
+                                  private_hearing_required_flag,
+                                  lead_judge_contract_type,
+                                  first_date_time_of_hearing_must_be,
+                                  hmcts_service_code,
+                                  case_reference,
+                                  hearing_request_received_date_time,
+                                  external_case_reference,
+                                  case_url_context_path,
+                                  hmcts_internal_case_name,
+                                  public_case_name,
+                                  additional_security_required_flag,
+                                  owning_location_id,
+                                  case_restricted_flag,
+                                  case_sla_start_date,
+                                  hearing_request_version,
+                                  hearing_id,
+                                  interpreter_booking_required_flag,
+                                  listing_comments, requester,
+                                  hearing_window_start_date_range,
+                                  hearing_window_end_date_range)
+VALUES ('t', 'Some hearing type2', 62, 'Priority type2', 5, 't', 'f', 'AB333', null, 'XYZ1', 1111222233335555,
+        '2020-08-10 11:20:00', 'EXT/REF783', 'https://www.google.com', 'Internal case name2', 'Public case name2', 'f',
+        'CMLC333', 't', '2020-10-10 00:00:00', 1, 2000000011, 't', 'Some listing comments2', 'Some judge2',
+        '2021-11-01 00:00:00', '2021-11-12 00:00:00'),
+
+       ('t', 'Some hearing type', 60, 'Priority type', 4, 'f', 'f', 'AB123', null, 'ABA1', 1111222233334455,
+        '2021-08-10 11:20:00', 'EXT/REF123', 'https://www.google.com', 'Internal case name', 'Public case name', 't',
+        'CMLC123', 't', '2021-10-10 00:00:00', 1, 2000000012, 't', 'Some listing comments', 'Some judge',
+        '2021-11-01 00:00:00', '2021-11-12 00:00:00');
+
+INSERT INTO change_reasons (id, change_reason_type, case_hearing_id)
+VALUES (1, 'reason 1', 1),
+       (2, 'reason 2', 1),
+       (3, 'reason 3', 1),
+       (4, 'reason A', 2),
+       (5, 'reason B', 2)
+

--- a/src/main/java/uk/gov/hmcts/reform/hmc/data/CaseHearingRequestEntity.java
+++ b/src/main/java/uk/gov/hmcts/reform/hmc/data/CaseHearingRequestEntity.java
@@ -121,9 +121,6 @@ public class CaseHearingRequestEntity extends BaseEntity implements Cloneable, S
     @Column(name = "hearing_request_received_date_time", nullable = false)
     private LocalDateTime hearingRequestReceivedDateTime;
 
-    @Column(name = "amend_reason_code")
-    private String amendReasonCode;
-
     @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "hearing_id")
     private HearingEntity hearing;
@@ -162,6 +159,10 @@ public class CaseHearingRequestEntity extends BaseEntity implements Cloneable, S
     @LazyCollection(LazyCollectionOption.FALSE)
     private List<HearingChannelsEntity> hearingChannels;
 
+    @OneToMany(mappedBy = "caseHearing", cascade = CascadeType.PERSIST, orphanRemoval = true)
+    @LazyCollection(LazyCollectionOption.FALSE)
+    private List<ChangeReasonsEntity> amendReasonCodes;
+
     @Override
     public Object clone() throws CloneNotSupportedException {
         CaseHearingRequestEntity cloned = (CaseHearingRequestEntity)super.clone();
@@ -175,6 +176,7 @@ public class CaseHearingRequestEntity extends BaseEntity implements Cloneable, S
         clonePanelSpecialisms(cloned);
         clonePanelUserRequirements(cloned);
         cloneHearingChannels(cloned);
+        cloneAmendReasonCodes(cloned);
         cloned.setCaseHearingID(null);
         return cloned;
     }
@@ -343,5 +345,18 @@ public class CaseHearingRequestEntity extends BaseEntity implements Cloneable, S
             }
         }
         cloned.setHearingChannels(hearingChannelsList);
+    }
+
+    private void cloneAmendReasonCodes(CaseHearingRequestEntity cloned) throws CloneNotSupportedException {
+        List<ChangeReasonsEntity> changeReasonsEntityList = new ArrayList<>();
+        if (null != cloned.getAmendReasonCodes()) {
+            for (ChangeReasonsEntity hce : cloned.getAmendReasonCodes()) {
+                ChangeReasonsEntity clonedSubValue = (ChangeReasonsEntity) hce.clone();
+                clonedSubValue.setId(null);
+                clonedSubValue.setCaseHearing(cloned);
+                changeReasonsEntityList.add(clonedSubValue);
+            }
+        }
+        cloned.setAmendReasonCodes(changeReasonsEntityList);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/hmc/data/CaseHearingRequestEntity.java
+++ b/src/main/java/uk/gov/hmcts/reform/hmc/data/CaseHearingRequestEntity.java
@@ -176,7 +176,6 @@ public class CaseHearingRequestEntity extends BaseEntity implements Cloneable, S
         clonePanelSpecialisms(cloned);
         clonePanelUserRequirements(cloned);
         cloneHearingChannels(cloned);
-        cloneAmendReasonCodes(cloned);
         cloned.setCaseHearingID(null);
         return cloned;
     }
@@ -345,18 +344,5 @@ public class CaseHearingRequestEntity extends BaseEntity implements Cloneable, S
             }
         }
         cloned.setHearingChannels(hearingChannelsList);
-    }
-
-    private void cloneAmendReasonCodes(CaseHearingRequestEntity cloned) throws CloneNotSupportedException {
-        List<ChangeReasonsEntity> changeReasonsEntityList = new ArrayList<>();
-        if (null != cloned.getAmendReasonCodes()) {
-            for (ChangeReasonsEntity hce : cloned.getAmendReasonCodes()) {
-                ChangeReasonsEntity clonedSubValue = (ChangeReasonsEntity) hce.clone();
-                clonedSubValue.setId(null);
-                clonedSubValue.setCaseHearing(cloned);
-                changeReasonsEntityList.add(clonedSubValue);
-            }
-        }
-        cloned.setAmendReasonCodes(changeReasonsEntityList);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/hmc/data/CaseHearingRequestEntity.java
+++ b/src/main/java/uk/gov/hmcts/reform/hmc/data/CaseHearingRequestEntity.java
@@ -11,6 +11,7 @@ import java.io.Serializable;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import javax.persistence.CascadeType;
@@ -177,6 +178,7 @@ public class CaseHearingRequestEntity extends BaseEntity implements Cloneable, S
         clonePanelUserRequirements(cloned);
         cloneHearingChannels(cloned);
         cloned.setCaseHearingID(null);
+        cloned.setAmendReasonCodes(Collections.emptyList());
         return cloned;
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/hmc/data/ChangeReasonsEntity.java
+++ b/src/main/java/uk/gov/hmcts/reform/hmc/data/ChangeReasonsEntity.java
@@ -1,0 +1,45 @@
+package uk.gov.hmcts.reform.hmc.data;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+import java.io.Serializable;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.PrimaryKeyJoinColumn;
+import javax.persistence.SecondaryTable;
+import javax.persistence.Table;
+
+@Table(name = "change_reasons")
+@EqualsAndHashCode(callSuper = true)
+@Entity
+@Data
+@SecondaryTable(name = "CASE_HEARING_REQUEST",
+    pkJoinColumns = {
+        @PrimaryKeyJoinColumn(name = "CASE_HEARING_ID")})
+public class ChangeReasonsEntity extends BaseEntity implements Serializable, Cloneable {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY,
+        generator = "change_reasons_id_seq")
+    @Column(name = "id")
+    private Long id;
+
+    @Column(name = "change_reason_type")
+    private String changeReasonType;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "case_hearing_id")
+    private CaseHearingRequestEntity caseHearing;
+
+    @Override
+    public Object clone() throws CloneNotSupportedException {
+        return super.clone();
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/hmc/data/ChangeReasonsEntity.java
+++ b/src/main/java/uk/gov/hmcts/reform/hmc/data/ChangeReasonsEntity.java
@@ -23,7 +23,9 @@ import javax.persistence.Table;
 @SecondaryTable(name = "CASE_HEARING_REQUEST",
     pkJoinColumns = {
         @PrimaryKeyJoinColumn(name = "CASE_HEARING_ID")})
-public class ChangeReasonsEntity extends BaseEntity implements Serializable, Cloneable {
+public class ChangeReasonsEntity extends BaseEntity implements Serializable {
+
+    private static final long serialVersionUID = 4353447468967037802L;
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY,
@@ -37,9 +39,4 @@ public class ChangeReasonsEntity extends BaseEntity implements Serializable, Clo
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "case_hearing_id")
     private CaseHearingRequestEntity caseHearing;
-
-    @Override
-    public Object clone() throws CloneNotSupportedException {
-        return super.clone();
-    }
 }

--- a/src/main/java/uk/gov/hmcts/reform/hmc/exceptions/ValidationError.java
+++ b/src/main/java/uk/gov/hmcts/reform/hmc/exceptions/ValidationError.java
@@ -257,7 +257,7 @@ public final class ValidationError {
     public static final String LIST_ASSIST_FAILED_TO_RESPOND = "006 List Assist failed to respond";
     public static final String LIST_ASSIST_CASE_STATUS_NULL = "List assist case status can not be null or empty";
     public static final String INVALID_DURATION_DETAILS = "Invalid duration details";
-    public static final String AMEND_REASON_CODE_MAX_LENGTH = "Amend reason code must not be more than "
+    public static final String AMEND_REASON_CODE_MAX_LENGTH = "Amend reason code must be at least 1 but no more than "
         + "70 " + CHARACTERS_LONG;
     public static final String INVALID_AMEND_REASON_CODE = "Amend reason code details are required";
 

--- a/src/main/java/uk/gov/hmcts/reform/hmc/helper/CaseHearingRequestMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/hmc/helper/CaseHearingRequestMapper.java
@@ -68,7 +68,6 @@ public class CaseHearingRequestMapper {
                                                                   .getDateRangeEnd());
         caseHearingRequestEntity.setHearingRequestReceivedDateTime(currentTime());
         caseHearingRequestEntity.setHearing(hearingEntity);
-        caseHearingRequestEntity.setAmendReasonCode(hearingDetails.getAmendReasonCode());
         return caseHearingRequestEntity;
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/hmc/helper/ChangeReasonsMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/hmc/helper/ChangeReasonsMapper.java
@@ -1,0 +1,29 @@
+package uk.gov.hmcts.reform.hmc.helper;
+
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.hmc.data.CaseHearingRequestEntity;
+import uk.gov.hmcts.reform.hmc.data.ChangeReasonsEntity;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+public class ChangeReasonsMapper {
+
+    public List<ChangeReasonsEntity> modelToEntity(List<String> changeReasons,
+                                                   CaseHearingRequestEntity caseHearingRequestEntity) {
+        if (changeReasons == null) {
+            return Collections.emptyList();
+        } else {
+            return changeReasons.stream()
+                    .map(changeReason -> {
+                        ChangeReasonsEntity entity = new ChangeReasonsEntity();
+                        entity.setChangeReasonType(changeReason);
+                        entity.setCaseHearing(caseHearingRequestEntity);
+                        return entity;
+                    })
+                    .collect(Collectors.toList());
+        }
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/hmc/helper/HearingDetailsMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/hmc/helper/HearingDetailsMapper.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.reform.hmc.helper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.hmc.data.CaseHearingRequestEntity;
+import uk.gov.hmcts.reform.hmc.data.ChangeReasonsEntity;
 import uk.gov.hmcts.reform.hmc.data.HearingChannelsEntity;
 import uk.gov.hmcts.reform.hmc.data.NonStandardDurationsEntity;
 import uk.gov.hmcts.reform.hmc.data.PanelAuthorisationRequirementsEntity;
@@ -37,6 +38,8 @@ public class HearingDetailsMapper {
 
     private HearingChannelsMapper hearingChannelsMapper;
 
+    private ChangeReasonsMapper changeReasonsMapper;
+
     @Autowired
     public HearingDetailsMapper(NonStandardDurationsMapper nonStandardDurationsMapper,
                                 RequiredLocationsMapper requiredLocationsMapper,
@@ -45,7 +48,8 @@ public class HearingDetailsMapper {
                                 PanelAuthorisationRequirementsMapper panelAuthorisationRequirementsMapper,
                                 PanelSpecialismsMapper panelSpecialismsMapper,
                                 PanelUserRequirementsMapper panelUserRequirementsMapper,
-                                HearingChannelsMapper hearingChannelsMapper) {
+                                HearingChannelsMapper hearingChannelsMapper,
+                                ChangeReasonsMapper changeReasonsMapper) {
         this.nonStandardDurationsMapper = nonStandardDurationsMapper;
         this.requiredLocationsMapper = requiredLocationsMapper;
         this.requiredFacilitiesMapper = requiredFacilitiesMapper;
@@ -54,12 +58,14 @@ public class HearingDetailsMapper {
         this.panelSpecialismsMapper = panelSpecialismsMapper;
         this.panelUserRequirementsMapper = panelUserRequirementsMapper;
         this.hearingChannelsMapper = hearingChannelsMapper;
+        this.changeReasonsMapper = changeReasonsMapper;
     }
 
     public void mapHearingDetails(HearingDetails hearingDetails, CaseHearingRequestEntity caseHearingRequestEntity) {
         setRequiredLocations(hearingDetails.getHearingLocations(), caseHearingRequestEntity);
         setPanelDetails(hearingDetails, caseHearingRequestEntity);
         setHearingChannels(hearingDetails.getHearingChannels(), caseHearingRequestEntity);
+        setChangeReasons(hearingDetails.getAmendReasonCodes(), caseHearingRequestEntity);
 
         if (hearingDetails.getFacilitiesRequired() != null) {
             setRequiredFacilities(hearingDetails.getFacilitiesRequired(), caseHearingRequestEntity);
@@ -139,5 +145,12 @@ public class HearingDetailsMapper {
         final List<HearingChannelsEntity> hearingChannelsEntities =
             hearingChannelsMapper.modelToEntity(hearingChannels, caseHearingRequestEntity);
         caseHearingRequestEntity.setHearingChannels(hearingChannelsEntities);
+    }
+
+    private void setChangeReasons(List<String> changeReasons,
+                                    CaseHearingRequestEntity caseHearingRequestEntity) {
+        final List<ChangeReasonsEntity> changeReasonsEntities =
+                changeReasonsMapper.modelToEntity(changeReasons, caseHearingRequestEntity);
+        caseHearingRequestEntity.setAmendReasonCodes(changeReasonsEntities);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/hmc/helper/hmi/HmiSubmitHearingRequestMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/hmc/helper/hmi/HmiSubmitHearingRequestMapper.java
@@ -8,6 +8,8 @@ import uk.gov.hmcts.reform.hmc.model.UpdateHearingRequest;
 import uk.gov.hmcts.reform.hmc.model.hmi.HmiHearingRequest;
 import uk.gov.hmcts.reform.hmc.model.hmi.HmiSubmitHearingRequest;
 
+import java.util.List;
+
 @Component
 public class HmiSubmitHearingRequestMapper {
 
@@ -31,7 +33,7 @@ public class HmiSubmitHearingRequestMapper {
         if (hearingRequest instanceof UpdateHearingRequest) {
             UpdateHearingRequest request = (UpdateHearingRequest) hearingRequest;
             if (null != request.getRequestDetails()) {
-                request.getHearingDetails().setAmendReasonCode(Constants.AMEND_REASON_CODE);
+                request.getHearingDetails().setAmendReasonCodes(List.of(Constants.AMEND_REASON_CODE));
                 versionNumber = request.getRequestDetails().getVersionNumber() + 1;
             }
         }

--- a/src/main/java/uk/gov/hmcts/reform/hmc/helper/hmi/HmiSubmitHearingRequestMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/hmc/helper/hmi/HmiSubmitHearingRequestMapper.java
@@ -2,13 +2,10 @@ package uk.gov.hmcts.reform.hmc.helper.hmi;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-import uk.gov.hmcts.reform.hmc.constants.Constants;
 import uk.gov.hmcts.reform.hmc.model.HearingRequest;
 import uk.gov.hmcts.reform.hmc.model.UpdateHearingRequest;
 import uk.gov.hmcts.reform.hmc.model.hmi.HmiHearingRequest;
 import uk.gov.hmcts.reform.hmc.model.hmi.HmiSubmitHearingRequest;
-
-import java.util.List;
 
 @Component
 public class HmiSubmitHearingRequestMapper {
@@ -33,7 +30,6 @@ public class HmiSubmitHearingRequestMapper {
         if (hearingRequest instanceof UpdateHearingRequest) {
             UpdateHearingRequest request = (UpdateHearingRequest) hearingRequest;
             if (null != request.getRequestDetails()) {
-                request.getHearingDetails().setAmendReasonCodes(List.of(Constants.AMEND_REASON_CODE));
                 versionNumber = request.getRequestDetails().getVersionNumber() + 1;
             }
         }

--- a/src/main/java/uk/gov/hmcts/reform/hmc/helper/hmi/ListingMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/hmc/helper/hmi/ListingMapper.java
@@ -40,7 +40,8 @@ public class ListingMapper {
             .listingJohs(listingJohsMapper.getListingJohs(hearingDetails.getPanelRequirements()))
             .listingHearingChannels(hearingDetails.getHearingChannels())
             .listingLocations(listingLocationsMapper.getListingLocations(hearingDetails.getHearingLocations()))
-            .amendReasonCode(hearingDetails.getAmendReasonCode())
+            .amendReasonCode(hearingDetails.getAmendReasonCodes() == null ? null :
+                    String.join(",", hearingDetails.getAmendReasonCodes()))
             .listingJohSpecialisms(hearingDetails.getPanelRequirements().getPanelSpecialisms())
             .listingJohTickets(hearingDetails.getPanelRequirements().getAuthorisationSubType())
             .listingOtherConsiderations(

--- a/src/main/java/uk/gov/hmcts/reform/hmc/helper/hmi/ListingMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/hmc/helper/hmi/ListingMapper.java
@@ -1,7 +1,9 @@
 package uk.gov.hmcts.reform.hmc.helper.hmi;
 
+import io.jsonwebtoken.lang.Collections;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.hmc.constants.Constants;
 import uk.gov.hmcts.reform.hmc.model.HearingDetails;
 import uk.gov.hmcts.reform.hmc.model.hmi.Listing;
 import uk.gov.hmcts.reform.hmc.model.hmi.ListingMultiDay;
@@ -40,8 +42,6 @@ public class ListingMapper {
             .listingJohs(listingJohsMapper.getListingJohs(hearingDetails.getPanelRequirements()))
             .listingHearingChannels(hearingDetails.getHearingChannels())
             .listingLocations(listingLocationsMapper.getListingLocations(hearingDetails.getHearingLocations()))
-            .amendReasonCode(hearingDetails.getAmendReasonCodes() == null ? null :
-                    String.join(",", hearingDetails.getAmendReasonCodes()))
             .listingJohSpecialisms(hearingDetails.getPanelRequirements().getPanelSpecialisms())
             .listingJohTickets(hearingDetails.getPanelRequirements().getAuthorisationSubType())
             .listingOtherConsiderations(
@@ -67,6 +67,11 @@ public class ListingMapper {
         } else {
             listing.setListingDuration(hearingDetails.getDuration());
         }
+
+        if (!Collections.isEmpty(hearingDetails.getAmendReasonCodes())) {
+            listing.setAmendReasonCode(Constants.AMEND_REASON_CODE);
+        }
+
         return listing;
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/hmc/model/HearingDetails.java
+++ b/src/main/java/uk/gov/hmcts/reform/hmc/model/HearingDetails.java
@@ -72,8 +72,9 @@ public class HearingDetails {
 
     private Boolean hearingIsLinkedFlag;
 
-    @Size(max = 70, message = ValidationError.AMEND_REASON_CODE_MAX_LENGTH)
-    private String amendReasonCode;
+    @Valid
+    @NotEmpty(message = ValidationError.INVALID_AMEND_REASON_CODE)
+    private List<@Size(max = 70, message = ValidationError.AMEND_REASON_CODE_MAX_LENGTH) String> amendReasonCodes;
 
     @Valid
     @NotNull(message = ValidationError.HEARING_CHANNEL_EMPTY)

--- a/src/main/java/uk/gov/hmcts/reform/hmc/model/HearingDetails.java
+++ b/src/main/java/uk/gov/hmcts/reform/hmc/model/HearingDetails.java
@@ -14,6 +14,7 @@ import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 
 import static uk.gov.hmcts.reform.hmc.constants.Constants.DURATION_OF_DAY;
+import static uk.gov.hmcts.reform.hmc.exceptions.ValidationError.AMEND_REASON_CODE_MAX_LENGTH;
 import static uk.gov.hmcts.reform.hmc.exceptions.ValidationError.FACILITIES_REQUIRED_MAX_LENGTH_MSG;
 
 @Data
@@ -72,9 +73,7 @@ public class HearingDetails {
 
     private Boolean hearingIsLinkedFlag;
 
-    @Valid
-    @NotEmpty(message = ValidationError.INVALID_AMEND_REASON_CODE)
-    private List<@Size(max = 70, message = ValidationError.AMEND_REASON_CODE_MAX_LENGTH) String> amendReasonCodes;
+    private List<@Size(min = 1, max = 70, message = AMEND_REASON_CODE_MAX_LENGTH) String> amendReasonCodes;
 
     @Valid
     @NotNull(message = ValidationError.HEARING_CHANNEL_EMPTY)

--- a/src/main/java/uk/gov/hmcts/reform/hmc/repository/ChangeReasonsRepository.java
+++ b/src/main/java/uk/gov/hmcts/reform/hmc/repository/ChangeReasonsRepository.java
@@ -1,0 +1,13 @@
+package uk.gov.hmcts.reform.hmc.repository;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import uk.gov.hmcts.reform.hmc.data.ChangeReasonsEntity;
+
+@Transactional(propagation = Propagation.REQUIRES_NEW)
+@Repository
+public interface ChangeReasonsRepository extends CrudRepository<ChangeReasonsEntity, Long> {
+
+}

--- a/src/main/java/uk/gov/hmcts/reform/hmc/service/HearingManagementServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/hmc/service/HearingManagementServiceImpl.java
@@ -68,6 +68,7 @@ import static uk.gov.hmcts.reform.hmc.exceptions.ValidationError.HEARING_ACTUALS
 import static uk.gov.hmcts.reform.hmc.exceptions.ValidationError.HEARING_ID_NOT_FOUND;
 import static uk.gov.hmcts.reform.hmc.exceptions.ValidationError.HEARING_WINDOW_DETAILS_ARE_INVALID;
 import static uk.gov.hmcts.reform.hmc.exceptions.ValidationError.HEARING_WINDOW_EMPTY_NULL;
+import static uk.gov.hmcts.reform.hmc.exceptions.ValidationError.INVALID_AMEND_REASON_CODE;
 import static uk.gov.hmcts.reform.hmc.exceptions.ValidationError.INVALID_DELETE_HEARING_STATUS;
 import static uk.gov.hmcts.reform.hmc.exceptions.ValidationError.INVALID_DURATION_DETAILS;
 import static uk.gov.hmcts.reform.hmc.exceptions.ValidationError.INVALID_HEARING_REQUEST_DETAILS;
@@ -323,8 +324,15 @@ public class HearingManagementServiceImpl implements HearingManagementService {
     private void validateHearingRequest(UpdateHearingRequest hearingRequest) {
         validateHearingRequestDetails(hearingRequest);
         validateHearingDetails(hearingRequest.getHearingDetails());
+        validateAmendReasonCodesForUpdate(hearingRequest.getHearingDetails().getAmendReasonCodes());
         if (hearingRequest.getPartyDetails() != null) {
             validatePartyDetails(hearingRequest.getPartyDetails());
+        }
+    }
+
+    private void validateAmendReasonCodesForUpdate(List<String> amendReasonCodes) {
+        if (amendReasonCodes == null || amendReasonCodes.isEmpty()) {
+            throw new BadRequestException(INVALID_AMEND_REASON_CODE);
         }
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/hmc/service/HearingManagementServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/hmc/service/HearingManagementServiceImpl.java
@@ -68,7 +68,6 @@ import static uk.gov.hmcts.reform.hmc.exceptions.ValidationError.HEARING_ACTUALS
 import static uk.gov.hmcts.reform.hmc.exceptions.ValidationError.HEARING_ID_NOT_FOUND;
 import static uk.gov.hmcts.reform.hmc.exceptions.ValidationError.HEARING_WINDOW_DETAILS_ARE_INVALID;
 import static uk.gov.hmcts.reform.hmc.exceptions.ValidationError.HEARING_WINDOW_EMPTY_NULL;
-import static uk.gov.hmcts.reform.hmc.exceptions.ValidationError.INVALID_AMEND_REASON_CODE;
 import static uk.gov.hmcts.reform.hmc.exceptions.ValidationError.INVALID_DELETE_HEARING_STATUS;
 import static uk.gov.hmcts.reform.hmc.exceptions.ValidationError.INVALID_DURATION_DETAILS;
 import static uk.gov.hmcts.reform.hmc.exceptions.ValidationError.INVALID_HEARING_REQUEST_DETAILS;
@@ -324,15 +323,8 @@ public class HearingManagementServiceImpl implements HearingManagementService {
     private void validateHearingRequest(UpdateHearingRequest hearingRequest) {
         validateHearingRequestDetails(hearingRequest);
         validateHearingDetails(hearingRequest.getHearingDetails());
-        validateAmendReasonCodeForUpdate(hearingRequest.getHearingDetails().getAmendReasonCode());
         if (hearingRequest.getPartyDetails() != null) {
             validatePartyDetails(hearingRequest.getPartyDetails());
-        }
-    }
-
-    private void validateAmendReasonCodeForUpdate(String amendReasonCode) {
-        if (amendReasonCode == null || amendReasonCode.isEmpty()) {
-            throw new BadRequestException(INVALID_AMEND_REASON_CODE);
         }
     }
 

--- a/src/main/resources/db/migration/V20220623_307.1__HMAN-307-DropAmendReasonCodeColumn.sql
+++ b/src/main/resources/db/migration/V20220623_307.1__HMAN-307-DropAmendReasonCodeColumn.sql
@@ -1,0 +1,1 @@
+ALTER TABLE public.case_hearing_request DROP COLUMN amend_reason_code;

--- a/src/main/resources/db/migration/V20220623_307__HMAN-307-CreateChangeReasonsTable.sql
+++ b/src/main/resources/db/migration/V20220623_307__HMAN-307-CreateChangeReasonsTable.sql
@@ -1,0 +1,23 @@
+CREATE TABLE public.change_reasons (id bigint not null,
+                                    case_hearing_id bigint not null,
+                                    change_reason_type varchar(70) not null,
+                                    created_date_time timestamp without time zone
+);
+
+ALTER TABLE ONLY public.change_reasons
+     ADD CONSTRAINT change_reasons_pkey PRIMARY KEY (id);
+
+CREATE SEQUENCE public.change_reasons_id_seq
+    start with 1
+    increment by 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+ALTER SEQUENCE public.change_reasons_id_seq OWNED BY public.change_reasons.id;
+
+ALTER TABLE ONLY public.change_reasons ALTER COLUMN id SET DEFAULT nextval('public.cancellation_reasons_id_seq'::regclass);
+
+ALTER TABLE ONLY public.change_reasons
+    ADD CONSTRAINT fk_change_reasons_case_hearing_request FOREIGN KEY (case_hearing_id)
+        REFERENCES public.case_hearing_request(case_hearing_id);

--- a/src/test/java/uk/gov/hmcts/reform/hmc/helper/ChangeReasonsMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/hmc/helper/ChangeReasonsMapperTest.java
@@ -1,0 +1,33 @@
+package uk.gov.hmcts.reform.hmc.helper;
+
+import org.junit.jupiter.api.Test;
+import uk.gov.hmcts.reform.hmc.data.CaseHearingRequestEntity;
+import uk.gov.hmcts.reform.hmc.data.ChangeReasonsEntity;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ChangeReasonsMapperTest {
+
+    @Test
+    void modelToEntityTest() {
+        ChangeReasonsMapper mapper = new ChangeReasonsMapper();
+        List<String> changeReasons = List.of("first reason", "second reason", "third reason");
+        List<ChangeReasonsEntity> entities = mapper.modelToEntity(changeReasons, new CaseHearingRequestEntity());
+
+        assertAll(
+                () -> assertEquals(changeReasons.size(), entities.size()),
+                () -> assertTrue(
+                        entities.stream()
+                                .map(ChangeReasonsEntity::getChangeReasonType)
+                                .collect(Collectors.toList())
+                                .containsAll(changeReasons)
+                )
+        );
+    }
+
+}

--- a/src/test/java/uk/gov/hmcts/reform/hmc/helper/hmi/ListingMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/hmc/helper/hmi/ListingMapperTest.java
@@ -24,6 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.hmc.constants.Constants.AMEND_REASON_CODE;
 import static uk.gov.hmcts.reform.hmc.constants.Constants.COURT;
 import static uk.gov.hmcts.reform.hmc.constants.Constants.DURATION_OF_DAY;
 import static uk.gov.hmcts.reform.hmc.constants.Constants.EPIMS;
@@ -49,7 +50,6 @@ class ListingMapperTest {
     private static final String HEARING_REQUESTER = "Some judge";
     private static final String ROLE_TYPE = "RoleType1";
     private static final String HEARING_CHANNEL = "someChannelType";
-    private static final String AMEND_REASON_CODE = "reason 1,reason 2";
     private static final LocalDateTime LOCAL_DATE_TIME = LocalDateTime.now();
     private static final Boolean hearingInWelsh = Boolean.TRUE;
     private static final String FACILITY_TYPE_1 = "consideration 1";

--- a/src/test/java/uk/gov/hmcts/reform/hmc/helper/hmi/ListingMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/hmc/helper/hmi/ListingMapperTest.java
@@ -49,7 +49,7 @@ class ListingMapperTest {
     private static final String HEARING_REQUESTER = "Some judge";
     private static final String ROLE_TYPE = "RoleType1";
     private static final String HEARING_CHANNEL = "someChannelType";
-    private static final String AMEND_REASON_CODE = "reason";
+    private static final String AMEND_REASON_CODE = "reason 1,reason 2";
     private static final LocalDateTime LOCAL_DATE_TIME = LocalDateTime.now();
     private static final Boolean hearingInWelsh = Boolean.TRUE;
     private static final String FACILITY_TYPE_1 = "consideration 1";

--- a/src/test/java/uk/gov/hmcts/reform/hmc/repository/ChangeReasonsRepositoryTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/hmc/repository/ChangeReasonsRepositoryTest.java
@@ -1,0 +1,44 @@
+package uk.gov.hmcts.reform.hmc.repository;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import uk.gov.hmcts.reform.hmc.data.CaseHearingRequestEntity;
+import uk.gov.hmcts.reform.hmc.data.ChangeReasonsEntity;
+import uk.gov.hmcts.reform.hmc.utils.TestingUtil;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+class ChangeReasonsRepositoryTest {
+
+    @Mock
+    private ChangeReasonsRepository changeReasonsRepository;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void testSaveChangeReason() {
+
+        final var changeReason = "Something Changed";
+        final var caseHearingId = 1L;
+        ChangeReasonsEntity changeReasonsEntity = new ChangeReasonsEntity();
+        changeReasonsEntity.setChangeReasonType(changeReason);
+
+        CaseHearingRequestEntity caseHearingRequestEntity = TestingUtil.caseHearingRequestEntity();
+        caseHearingRequestEntity.setCaseHearingID(caseHearingId);
+        changeReasonsEntity.setCaseHearing(caseHearingRequestEntity);
+
+        when(changeReasonsRepository.save(any())).thenReturn(changeReasonsEntity);
+
+        ChangeReasonsEntity savedEntity = changeReasonsRepository.save(changeReasonsEntity);
+        assertEquals(changeReason, savedEntity.getChangeReasonType());
+        assertEquals(1L, savedEntity.getCaseHearing().getCaseHearingID());
+    }
+
+}

--- a/src/test/java/uk/gov/hmcts/reform/hmc/service/HearingManagementServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/hmc/service/HearingManagementServiceTest.java
@@ -1127,7 +1127,7 @@ class HearingManagementServiceTest {
             final UpdateHearingRequest request = new UpdateHearingRequest();
             HearingDetails hearingDetails = new HearingDetails();
             hearingDetails.setAutoListFlag(true);
-            hearingDetails.setAmendReasonCode("reason");
+            hearingDetails.setAmendReasonCodes(List.of("reason"));
             HearingWindow hearingWindow = new HearingWindow();
             hearingDetails.setHearingWindow(hearingWindow);
             request.setHearingDetails(hearingDetails);

--- a/src/test/java/uk/gov/hmcts/reform/hmc/utils/TestingUtil.java
+++ b/src/test/java/uk/gov/hmcts/reform/hmc/utils/TestingUtil.java
@@ -107,7 +107,6 @@ public class TestingUtil {
         hearingDetails.setHearingPriorityType("Priority type");
         hearingDetails.setHearingIsLinkedFlag(Boolean.TRUE);
         hearingDetails.setHearingChannels(getHearingChannelsList());
-        hearingDetails.setAmendReasonCodes(List.of("reason 1"));
         HearingLocation location1 = new HearingLocation();
         location1.setLocationType(LocationType.CLUSTER.getLabel());
         location1.setLocationId("Location Id");

--- a/src/test/java/uk/gov/hmcts/reform/hmc/utils/TestingUtil.java
+++ b/src/test/java/uk/gov/hmcts/reform/hmc/utils/TestingUtil.java
@@ -107,6 +107,7 @@ public class TestingUtil {
         hearingDetails.setHearingPriorityType("Priority type");
         hearingDetails.setHearingIsLinkedFlag(Boolean.TRUE);
         hearingDetails.setHearingChannels(getHearingChannelsList());
+        hearingDetails.setAmendReasonCodes(List.of("reason 1"));
         HearingLocation location1 = new HearingLocation();
         location1.setLocationType(LocationType.CLUSTER.getLabel());
         location1.setLocationId("Location Id");
@@ -406,7 +407,7 @@ public class TestingUtil {
     public static UpdateHearingRequest updateHearingRequest(int version) {
         UpdateHearingRequest request = new UpdateHearingRequest();
         HearingDetails hearingDetails = hearingDetails();
-        hearingDetails.setAmendReasonCode("reason");
+        hearingDetails.setAmendReasonCodes(List.of("reason"));
         request.setHearingDetails(hearingDetails);
         request.setCaseDetails(caseDetails());
         request.getHearingDetails().setPanelRequirements(TestingUtil.panelRequirements());
@@ -419,7 +420,7 @@ public class TestingUtil {
     public static UpdateHearingRequest updateHearingRequestWithCaseSubType(int version) {
         UpdateHearingRequest request = new UpdateHearingRequest();
         HearingDetails hearingDetails = hearingDetails();
-        hearingDetails.setAmendReasonCode("reason");
+        hearingDetails.setAmendReasonCodes(List.of("reason"));
         request.setHearingDetails(hearingDetails);
         request.setCaseDetails(caseDetailsWithCaseSubType());
         request.getHearingDetails().setPanelRequirements(TestingUtil.panelRequirements());
@@ -432,7 +433,7 @@ public class TestingUtil {
     public static UpdateHearingRequest validUpdateHearingRequest() {
         UpdateHearingRequest request = new UpdateHearingRequest();
         HearingDetails hearingDetails = hearingDetails();
-        hearingDetails.setAmendReasonCode("reason");
+        hearingDetails.setAmendReasonCodes(List.of("reason 1", "reason 2"));
         request.setHearingDetails(hearingDetails);
         CaseDetails caseDetails = getValidCaseDetails();
         request.setCaseDetails(caseDetails);
@@ -1167,7 +1168,7 @@ public class TestingUtil {
     public static HearingDetails hearingDetailsWithAllFields() {
         HearingDetails hearingDetails = new HearingDetails();
         hearingDetails.setAutoListFlag(true);
-        hearingDetails.setAmendReasonCode("reason");
+        hearingDetails.setAmendReasonCodes(List.of("reason 1", "reason 2"));
         hearingDetails.setHearingType("Some hearing type");
         HearingWindow hearingWindow = new HearingWindow();
         hearingWindow.setDateRangeEnd(LocalDate.parse("2017-03-01"));

--- a/src/test/java/uk/gov/hmcts/reform/hmc/validator/BeanValidatorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/hmc/validator/BeanValidatorTest.java
@@ -69,7 +69,7 @@ class BeanValidatorTest {
         List<String> validationErrors = new ArrayList<>();
         violations.forEach(e -> validationErrors.add(e.getMessage()));
         assertFalse(violations.isEmpty());
-        assertEquals(11, violations.size());
+        assertEquals(12, violations.size());
         assertTrue(validationErrors.contains(ValidationError.AUTO_LIST_FLAG_NULL_EMPTY));
         assertTrue(validationErrors.contains(ValidationError.HEARING_TYPE_MAX_LENGTH));
         assertTrue(validationErrors.contains(ValidationError.HEARING_WINDOW_NULL));
@@ -79,6 +79,7 @@ class BeanValidatorTest {
         assertTrue(validationErrors.contains(ValidationError.LEAD_JUDGE_CONTRACT_TYPE_MAX_LENGTH));
         assertTrue(validationErrors.contains(ValidationError.HEARING_LOCATION_EMPTY));
         assertTrue(validationErrors.contains(ValidationError.HEARING_CHANNEL_EMPTY));
+        assertTrue(validationErrors.contains(ValidationError.INVALID_AMEND_REASON_CODE));
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/hmc/validator/BeanValidatorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/hmc/validator/BeanValidatorTest.java
@@ -69,7 +69,7 @@ class BeanValidatorTest {
         List<String> validationErrors = new ArrayList<>();
         violations.forEach(e -> validationErrors.add(e.getMessage()));
         assertFalse(violations.isEmpty());
-        assertEquals(12, violations.size());
+        assertEquals(11, violations.size());
         assertTrue(validationErrors.contains(ValidationError.AUTO_LIST_FLAG_NULL_EMPTY));
         assertTrue(validationErrors.contains(ValidationError.HEARING_TYPE_MAX_LENGTH));
         assertTrue(validationErrors.contains(ValidationError.HEARING_WINDOW_NULL));
@@ -79,7 +79,6 @@ class BeanValidatorTest {
         assertTrue(validationErrors.contains(ValidationError.LEAD_JUDGE_CONTRACT_TYPE_MAX_LENGTH));
         assertTrue(validationErrors.contains(ValidationError.HEARING_LOCATION_EMPTY));
         assertTrue(validationErrors.contains(ValidationError.HEARING_CHANNEL_EMPTY));
-        assertTrue(validationErrors.contains(ValidationError.INVALID_AMEND_REASON_CODE));
     }
 
     @Test


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/HMAN-307

### Change description ###

At present amendReasonCode is string this needs to be updated as array of amendReasonCodes. We need to add a new table that will store the array values.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
