### PR TITLE
HMAN-308 - make cancellationReasonCode an array/List of Strings

### DIFF
--- a/src/contractTest/java/uk/gov/hmcts/reform/hmc/BasePactTesting.java
+++ b/src/contractTest/java/uk/gov/hmcts/reform/hmc/BasePactTesting.java
@@ -90,7 +90,7 @@ public class BasePactTesting {
      */
     protected DeleteHearingRequest generateDeleteHearingRequest() {
         DeleteHearingRequest deleteHearingRequest = new DeleteHearingRequest();
-        deleteHearingRequest.setCancellationReasonCode("1XXX1");
+        deleteHearingRequest.setCancellationReasonCodes(List.of("1XXX1"));
         return deleteHearingRequest;
     }
 

--- a/src/contractTest/java/uk/gov/hmcts/reform/hmc/utility/HearingResponsePactUtil.java
+++ b/src/contractTest/java/uk/gov/hmcts/reform/hmc/utility/HearingResponsePactUtil.java
@@ -462,7 +462,7 @@ public class HearingResponsePactUtil {
 
     private static DeleteHearingRequest generateDeleteHearingRequest() {
         DeleteHearingRequest deleteHearingRequest = new DeleteHearingRequest();
-        deleteHearingRequest.setCancellationReasonCode("REASONCODE25");
+        deleteHearingRequest.setCancellationReasonCodes(List.of("REASONCODE25"));
         return  deleteHearingRequest;
     }
 

--- a/src/integrationTest/java/uk/gov/hmcts/reform/hmc/controllers/HearingManagementControllerIT.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/hmc/controllers/HearingManagementControllerIT.java
@@ -15,6 +15,7 @@ import uk.gov.hmcts.reform.hmc.ApplicationParams;
 import uk.gov.hmcts.reform.hmc.BaseTest;
 import uk.gov.hmcts.reform.hmc.client.datastore.model.DataStoreCaseDetails;
 import uk.gov.hmcts.reform.hmc.config.MessageReaderFromQueueConfiguration;
+import uk.gov.hmcts.reform.hmc.data.CancellationReasonsEntity;
 import uk.gov.hmcts.reform.hmc.data.RoleAssignmentAttributesResource;
 import uk.gov.hmcts.reform.hmc.data.RoleAssignmentResource;
 import uk.gov.hmcts.reform.hmc.data.RoleAssignmentResponse;
@@ -35,6 +36,7 @@ import uk.gov.hmcts.reform.hmc.model.RequestDetails;
 import uk.gov.hmcts.reform.hmc.model.UnavailabilityDow;
 import uk.gov.hmcts.reform.hmc.model.UnavailabilityRanges;
 import uk.gov.hmcts.reform.hmc.model.UpdateHearingRequest;
+import uk.gov.hmcts.reform.hmc.repository.CancellationReasonsRepository;
 import uk.gov.hmcts.reform.hmc.utils.TestingUtil;
 
 import java.time.LocalDate;
@@ -44,6 +46,9 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.Spliterator;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.okJson;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
@@ -51,6 +56,9 @@ import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.Matchers.hasSize;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -111,6 +119,7 @@ import static uk.gov.hmcts.reform.hmc.exceptions.ValidationError.HMCTS_INTERNAL_
 import static uk.gov.hmcts.reform.hmc.exceptions.ValidationError.HMCTS_INTERNAL_CASE_NAME_MAX_LENGTH;
 import static uk.gov.hmcts.reform.hmc.exceptions.ValidationError.HMCTS_SERVICE_CODE_EMPTY_INVALID;
 import static uk.gov.hmcts.reform.hmc.exceptions.ValidationError.INTERPRETER_LANGUAGE_MAX_LENGTH;
+import static uk.gov.hmcts.reform.hmc.exceptions.ValidationError.INVALID_CANCELLATION_REASON_CODE;
 import static uk.gov.hmcts.reform.hmc.exceptions.ValidationError.INVALID_CASE_CATEGORIES;
 import static uk.gov.hmcts.reform.hmc.exceptions.ValidationError.INVALID_CASE_DETAILS;
 import static uk.gov.hmcts.reform.hmc.exceptions.ValidationError.INVALID_DELETE_HEARING_STATUS;
@@ -162,6 +171,7 @@ import static uk.gov.hmcts.reform.hmc.repository.DefaultRoleAssignmentRepository
 import static uk.gov.hmcts.reform.hmc.repository.DefaultRoleAssignmentRepository.ROLE_ASSIGNMENT_INVALID_ROLE;
 import static uk.gov.hmcts.reform.hmc.service.AccessControlServiceImpl.HEARING_MANAGER;
 import static uk.gov.hmcts.reform.hmc.service.AccessControlServiceImpl.HEARING_VIEWER;
+import static uk.gov.hmcts.reform.hmc.utils.TestingUtil.CANCELLATION_REASON_CODES;
 import static uk.gov.hmcts.reform.hmc.utils.TestingUtil.CASE_REFERENCE;
 
 class HearingManagementControllerIT extends BaseTest {
@@ -179,6 +189,9 @@ class HearingManagementControllerIT extends BaseTest {
 
     @Autowired
     private ApplicationParams applicationParams;
+
+    @Autowired
+    private CancellationReasonsRepository cancellationReasonsRepository;
 
     private static final String url = "/hearing";
     public static final String USER_ID = "e8275d41-7f22-4ee7-8ed3-14644d6db096";
@@ -573,7 +586,7 @@ class HearingManagementControllerIT extends BaseTest {
 
     @Test
     @Sql(scripts = {DELETE_HEARING_DATA_SCRIPT, INSERT_CASE_HEARING_DATA_SCRIPT})
-    void shouldReturn200_WhenDeleteHearingIdIsInValid() throws Exception {
+    void shouldReturn200_WhenDeleteHearingIdIsValid() throws Exception {
         DeleteHearingRequest deleteHearingRequest = TestingUtil.deleteHearingRequest();
         mockMvc.perform(delete(url + "/2000000000")
                             .contentType(MediaType.APPLICATION_JSON_VALUE)
@@ -584,6 +597,16 @@ class HearingManagementControllerIT extends BaseTest {
             .andExpect(jsonPath("$.versionNumber").value(2))
             .andExpect(jsonPath("$.timeStamp").value(IsNull.notNullValue()))
             .andReturn();
+
+        final Spliterator<CancellationReasonsEntity> spliterator =
+                cancellationReasonsRepository.findAll().spliterator();
+
+        assertEquals(2, spliterator.getExactSizeIfKnown());
+
+        assertTrue(StreamSupport.stream(spliterator, false)
+                .map(CancellationReasonsEntity::getCancellationReasonType)
+                .collect(Collectors.toList())
+                .containsAll(CANCELLATION_REASON_CODES));
     }
 
     @Test
@@ -615,9 +638,9 @@ class HearingManagementControllerIT extends BaseTest {
 
     @Test
     @Sql(scripts = {DELETE_HEARING_DATA_SCRIPT, INSERT_CASE_HEARING_DATA_SCRIPT})
-    void shouldReturn404_WhenCancellationReasonExceedsMaxLength() throws Exception {
+    void shouldReturn400_WhenCancellationReasonExceedsMaxLength() throws Exception {
         DeleteHearingRequest hearingRequest = new DeleteHearingRequest();
-        hearingRequest.setCancellationReasonCode("a".repeat(101));
+        hearingRequest.setCancellationReasonCodes(List.of("a".repeat(101)));
         mockMvc.perform(delete(url + "/2000000001")
                             .contentType(MediaType.APPLICATION_JSON_VALUE)
                             .content(objectMapper.writeValueAsString(hearingRequest)))
@@ -625,13 +648,63 @@ class HearingManagementControllerIT extends BaseTest {
             .andExpect(jsonPath("$.errors", hasSize(1)))
             .andExpect(jsonPath("$.errors", hasItems(CANCELLATION_REASON_CODE_MAX_LENGTH_MSG)))
             .andReturn();
+
+        assertFalse(cancellationReasonsRepository.findAll().iterator().hasNext());
     }
 
     @Test
     @Sql(scripts = {DELETE_HEARING_DATA_SCRIPT, INSERT_CASE_HEARING_DATA_SCRIPT})
-    void shouldReturn404_WhenCancellationReasonMaxLength() throws Exception {
+    void shouldReturn400_WhenCancellationReasonIsNull() throws Exception {
         DeleteHearingRequest hearingRequest = new DeleteHearingRequest();
-        hearingRequest.setCancellationReasonCode("a".repeat(100));
+        hearingRequest.setCancellationReasonCodes(null);
+        mockMvc.perform(delete(url + "/2000000001")
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .content(objectMapper.writeValueAsString(hearingRequest)))
+                .andExpect(status().is(400))
+                .andExpect(jsonPath("$.errors", hasSize(1)))
+                .andExpect(jsonPath("$.errors", hasItems(INVALID_CANCELLATION_REASON_CODE)))
+                .andReturn();
+
+        assertFalse(cancellationReasonsRepository.findAll().iterator().hasNext());
+    }
+
+    @Test
+    @Sql(scripts = {DELETE_HEARING_DATA_SCRIPT, INSERT_CASE_HEARING_DATA_SCRIPT})
+    void shouldReturn400_WhenCancellationReasonIsEmpty() throws Exception {
+        DeleteHearingRequest hearingRequest = new DeleteHearingRequest();
+        hearingRequest.setCancellationReasonCodes(Collections.emptyList());
+        mockMvc.perform(delete(url + "/2000000001")
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .content(objectMapper.writeValueAsString(hearingRequest)))
+                .andExpect(status().is(400))
+                .andExpect(jsonPath("$.errors", hasSize(1)))
+                .andExpect(jsonPath("$.errors", hasItems(INVALID_CANCELLATION_REASON_CODE)))
+                .andReturn();
+
+        assertFalse(cancellationReasonsRepository.findAll().iterator().hasNext());
+    }
+
+    @Test
+    @Sql(scripts = {DELETE_HEARING_DATA_SCRIPT, INSERT_CASE_HEARING_DATA_SCRIPT})
+    void shouldReturn400_WhenCancellationContainsAnEmptyString() throws Exception {
+        DeleteHearingRequest hearingRequest = new DeleteHearingRequest();
+        hearingRequest.setCancellationReasonCodes(List.of("reason", ""));
+        mockMvc.perform(delete(url + "/2000000001")
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .content(objectMapper.writeValueAsString(hearingRequest)))
+                .andExpect(status().is(400))
+                .andExpect(jsonPath("$.errors", hasSize(1)))
+                .andExpect(jsonPath("$.errors", hasItems(CANCELLATION_REASON_CODE_MAX_LENGTH_MSG)))
+                .andReturn();
+        assertFalse(cancellationReasonsRepository.findAll().iterator().hasNext());
+    }
+
+    @Test
+    @Sql(scripts = {DELETE_HEARING_DATA_SCRIPT, INSERT_CASE_HEARING_DATA_SCRIPT})
+    void shouldReturn200_WhenCancellationReasonIsMaxLength() throws Exception {
+        DeleteHearingRequest hearingRequest = new DeleteHearingRequest();
+        final String cancellationReasonCode = "a".repeat(100);
+        hearingRequest.setCancellationReasonCodes(List.of(cancellationReasonCode));
         mockMvc.perform(delete(url + "/2000000000")
                             .contentType(MediaType.APPLICATION_JSON_VALUE)
                             .content(objectMapper.writeValueAsString(hearingRequest)))
@@ -640,6 +713,9 @@ class HearingManagementControllerIT extends BaseTest {
             .andExpect(jsonPath("$.status").value(CANCELLATION_REQUESTED))
             .andExpect(jsonPath("$.timeStamp").value(IsNull.notNullValue()))
             .andReturn();
+
+        assertEquals(cancellationReasonCode,
+                cancellationReasonsRepository.findAll().iterator().next().getCancellationReasonType());
     }
 
 

--- a/src/main/java/uk/gov/hmcts/reform/hmc/data/CaseHearingRequestEntity.java
+++ b/src/main/java/uk/gov/hmcts/reform/hmc/data/CaseHearingRequestEntity.java
@@ -23,7 +23,6 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
-import javax.persistence.OneToOne;
 import javax.persistence.PrimaryKeyJoinColumn;
 import javax.persistence.SecondaryTable;
 import javax.persistence.Table;
@@ -155,8 +154,8 @@ public class CaseHearingRequestEntity extends BaseEntity implements Cloneable, S
     @OneToMany(mappedBy = "caseHearing", cascade = CascadeType.PERSIST, orphanRemoval = true)
     private List<PanelUserRequirementsEntity> panelUserRequirements;
 
-    @OneToOne(mappedBy = "caseHearing", cascade = CascadeType.PERSIST, orphanRemoval = true)
-    private CancellationReasonsEntity cancellationReason;
+    @OneToMany(mappedBy = "caseHearing", cascade = CascadeType.PERSIST, orphanRemoval = true)
+    private List<CancellationReasonsEntity> cancellationReasons;
 
     @OneToMany(mappedBy = "caseHearing", cascade = CascadeType.PERSIST, orphanRemoval = true)
     @LazyCollection(LazyCollectionOption.FALSE)

--- a/src/main/java/uk/gov/hmcts/reform/hmc/exceptions/ValidationError.java
+++ b/src/main/java/uk/gov/hmcts/reform/hmc/exceptions/ValidationError.java
@@ -117,7 +117,7 @@ public final class ValidationError {
         + "be present";
     public static final String INVALID_CANCELLATION_REASON_CODE = "Cancellation Reason code details are not present";
     public static final String CANCELLATION_REASON_CODE_MAX_LENGTH_MSG = "Cancellation Reason code "
-        + "length cannot be greater than 100 characters";
+        + "length must be at least 1 and no greater than 100 characters";
     public static final String INVALID_VERSION_NUMBER = "Invalid version number";
     public static final String INVALID_HEARING_ID_DETAILS = "Invalid hearing Id";
     public static final String CASE_NOT_FOUND = "Case could not be found";

--- a/src/main/java/uk/gov/hmcts/reform/hmc/helper/CaseHearingRequestMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/hmc/helper/CaseHearingRequestMapper.java
@@ -16,6 +16,7 @@ import uk.gov.hmcts.reform.hmc.model.HearingRequest;
 import java.time.Clock;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Component
 @Slf4j
@@ -83,9 +84,9 @@ public class CaseHearingRequestMapper {
             log.error("Error while reading the response:{}", e.getMessage());
         }
         caseHearingRequestNew.setVersionNumber(requestVersion);
-        caseHearingRequestNew.setCancellationReason(setCancellationReasonsEntity(
+        caseHearingRequestNew.setCancellationReasons(setCancellationReasonsEntities(
             deleteHearingRequest
-                .getCancellationReasonCode(),
+                .getCancellationReasonCodes(),
             caseHearingRequestNew
         ));
         caseHearingRequestNew.setHearingRequestReceivedDateTime(currentTime());
@@ -100,12 +101,15 @@ public class CaseHearingRequestMapper {
         caseHearingRequestEntity.setCaseCategories(caseCategoriesEntities);
     }
 
-    private CancellationReasonsEntity setCancellationReasonsEntity(String cancellationReasonCode,
-                                                                   CaseHearingRequestEntity caseHearingRequestEntity) {
-        final CancellationReasonsEntity cancellationReasonsEntity = new CancellationReasonsEntity();
-        cancellationReasonsEntity.setCaseHearing(caseHearingRequestEntity);
-        cancellationReasonsEntity.setCancellationReasonType(cancellationReasonCode);
-        return cancellationReasonsEntity;
+    private List<CancellationReasonsEntity> setCancellationReasonsEntities(List<String> cancellationReasonCodes,
+                                                                           CaseHearingRequestEntity
+                                                                                   caseHearingRequestEntity) {
+        return cancellationReasonCodes.stream().map(cancellationReasonCode -> {
+            CancellationReasonsEntity cancellationReasonsEntity = new CancellationReasonsEntity();
+            cancellationReasonsEntity.setCaseHearing(caseHearingRequestEntity);
+            cancellationReasonsEntity.setCancellationReasonType(cancellationReasonCode);
+            return cancellationReasonsEntity;
+        }).collect(Collectors.toList());
     }
 
     private LocalDateTime currentTime() {

--- a/src/main/java/uk/gov/hmcts/reform/hmc/model/DeleteHearingRequest.java
+++ b/src/main/java/uk/gov/hmcts/reform/hmc/model/DeleteHearingRequest.java
@@ -5,6 +5,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import uk.gov.hmcts.reform.hmc.exceptions.ValidationError;
 
+import java.util.List;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.Size;
 
@@ -16,7 +17,7 @@ import static uk.gov.hmcts.reform.hmc.exceptions.ValidationError.CANCELLATION_RE
 public class DeleteHearingRequest {
 
     @NotEmpty(message = ValidationError.INVALID_CANCELLATION_REASON_CODE)
-    @Size(max = 100, message = CANCELLATION_REASON_CODE_MAX_LENGTH_MSG)
-    private String cancellationReasonCode;
+    private List<@Size(min = 1, max = 100, message = CANCELLATION_REASON_CODE_MAX_LENGTH_MSG) String>
+            cancellationReasonCodes;
 
 }

--- a/src/test/java/uk/gov/hmcts/reform/hmc/controllers/HearingManagementControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/hmc/controllers/HearingManagementControllerTest.java
@@ -191,7 +191,7 @@ class HearingManagementControllerTest {
         @Test
         void shouldReturn404_whenDeleteRequestIdIsInvalid() {
             DeleteHearingRequest request = TestingUtil.deleteHearingRequest();
-            request.setCancellationReasonCode("");
+            request.setCancellationReasonCodes(List.of(""));
 
             HearingResponse hearingResponse = generateHearingResponse();
             when(hearingManagementService.deleteHearingRequest(any(), any())).thenReturn(hearingResponse);

--- a/src/test/java/uk/gov/hmcts/reform/hmc/utils/TestingUtil.java
+++ b/src/test/java/uk/gov/hmcts/reform/hmc/utils/TestingUtil.java
@@ -68,6 +68,7 @@ import uk.gov.hmcts.reform.hmc.model.UnavailabilityDow;
 import uk.gov.hmcts.reform.hmc.model.UnavailabilityRanges;
 import uk.gov.hmcts.reform.hmc.model.UpdateHearingRequest;
 
+import javax.validation.constraints.Size;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -85,6 +86,7 @@ public class TestingUtil {
 
     public static final String CASE_REFERENCE = "1111222233334444";
     public static final String INVALID_CASE_REFERENCE = "1111222233334445";
+    public static final List<String> CANCELLATION_REASON_CODES = List.of("test 1", "test 2");
     public static Long ID = 2000000000L;
 
     private TestingUtil() {
@@ -395,7 +397,7 @@ public class TestingUtil {
 
     public static DeleteHearingRequest deleteHearingRequest() {
         DeleteHearingRequest request = new DeleteHearingRequest();
-        request.setCancellationReasonCode("test");
+        request.setCancellationReasonCodes(CANCELLATION_REASON_CODES);
         return request;
     }
 


### PR DESCRIPTION

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/HMAN-308

### Change description ###

Update /hearing DELETE endpoint processing to use array of cancellationReasonCodes, rather than single String

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
