### PR TITLE
HMAN-311 - use `chart-hmc` chart

### DIFF
--- a/charts/hmc-cft-hearing-service/Chart.yaml
+++ b/charts/hmc-cft-hearing-service/Chart.yaml
@@ -10,7 +10,6 @@ dependencies:
   - name: java
     version: 3.7.3
     repository: 'https://hmctspublic.azurecr.io/helm/v1/repo/'
-  - name: servicebus
-    version: 0.3.0
+  - name: hmc
+    version: 0.0.1
     repository: 'https://hmctspublic.azurecr.io/helm/v1/repo/'
-    condition: servicebus.enabled

--- a/charts/hmc-cft-hearing-service/values.preview.template.yaml
+++ b/charts/hmc-cft-hearing-service/values.preview.template.yaml
@@ -34,16 +34,6 @@ java:
         - name: hmc-cft-hearing-service-s2s-secret
           alias: IDAM_KEY_CFT_HEARING_SERVICE
 
-servicebus:
-  enabled: true
-  teamName: CCD
-  resourceGroup: hmc-aks
-  serviceplan: standard
-  setup:
-    topics:
-      - name: hmc-to-cft
-    subscriptions:
-      - name: hmc-subs-to-cft
-    queues:
-      - name: hmc-from-hmi
-      - name: hmc-to-hmi
+hmc:
+  servicebus:
+    enabled: true

--- a/charts/hmc-cft-hearing-service/values.yaml
+++ b/charts/hmc-cft-hearing-service/values.yaml
@@ -60,5 +60,8 @@ java:
     GRANT_TYPE: client_credentials
     FH_BASE_URL: https://login.microsoftonline.com
 
-servicebus:
-  enabled: false
+hmc:
+  hearingService:
+    enabled: false
+  servicebus:
+    enabled: false


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/HMAN-311

### Change description ###

Use chart-hmc chart to enable following inbound and oubound adater + service bus services in preview env


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
