### PR TITLE
HMAN-336 Add new listLanguage field, apply population and update unit…

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/hmc/helper/hmi/ListingMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/hmc/helper/hmi/ListingMapper.java
@@ -51,6 +51,7 @@ public class ListingMapper {
             .listingLocations(listingLocationsMapper.getListingLocations(hearingDetails.getHearingLocations()))
             .listingJohSpecialisms(hearingDetails.getPanelRequirements().getPanelSpecialisms())
             .listingJohTickets(hearingDetails.getPanelRequirements().getAuthorisationSubType())
+            .listingLanguage(Boolean.TRUE.equals(hearingDetails.getHearingInWelshFlag()) ? "cym" : "ENG")
             .build();
 
         if (hearingDetails.getHearingWindow() != null) {

--- a/src/main/java/uk/gov/hmcts/reform/hmc/helper/hmi/ListingMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/hmc/helper/hmi/ListingMapper.java
@@ -23,6 +23,8 @@ import static uk.gov.hmcts.reform.hmc.constants.Constants.DURATION_OF_DAY;
 @Component
 public class ListingMapper {
 
+    public static final String WELSH_LANGUAGE_TRUE_VALUE = "cym";
+    public static final String WELSH_LANGUAGE_FALSE_VALUE = "ENG";
     private final ListingJohsMapper listingJohsMapper;
     private final ListingLocationsMapper listingLocationsMapper;
     private final RoomAttributesService roomAttributesService;
@@ -51,7 +53,8 @@ public class ListingMapper {
             .listingLocations(listingLocationsMapper.getListingLocations(hearingDetails.getHearingLocations()))
             .listingJohSpecialisms(hearingDetails.getPanelRequirements().getPanelSpecialisms())
             .listingJohTickets(hearingDetails.getPanelRequirements().getAuthorisationSubType())
-            .listingLanguage(Boolean.TRUE.equals(hearingDetails.getHearingInWelshFlag()) ? "cym" : "ENG")
+            .listingLanguage(Boolean.TRUE.equals(hearingDetails.getHearingInWelshFlag())
+                    ? WELSH_LANGUAGE_TRUE_VALUE : WELSH_LANGUAGE_FALSE_VALUE)
             .build();
 
         if (hearingDetails.getHearingWindow() != null) {

--- a/src/main/java/uk/gov/hmcts/reform/hmc/model/hmi/Listing.java
+++ b/src/main/java/uk/gov/hmcts/reform/hmc/model/hmi/Listing.java
@@ -57,5 +57,7 @@ public class Listing {
 
     private ListingMultiDay listingMultiDay;
 
+    private String listingLanguage;
+
     private List<String> roomAttributes;
 }

--- a/src/test/java/uk/gov/hmcts/reform/hmc/helper/hmi/ListingMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/hmc/helper/hmi/ListingMapperTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.reform.hmc.domain.model.enums.RoleType;
 import uk.gov.hmcts.reform.hmc.helper.HearingMapper;
 import uk.gov.hmcts.reform.hmc.model.HearingDetails;
 import uk.gov.hmcts.reform.hmc.model.HearingWindow;
@@ -57,6 +58,41 @@ class ListingMapperTest {
     private static final String ROLE_TYPE = "RoleType1";
     private static final String HEARING_CHANNEL = "someChannelType";
     private static final LocalDateTime LOCAL_DATE_TIME = LocalDateTime.now();
+
+    @Test
+    void shouldReturnListingWithNoWelshLanguageValue() {
+        HearingDetails hearingDetails = buildHearingDetails(150);
+        hearingDetails.setHearingInWelshFlag(false);
+        Listing listing = buildListing(hearingDetails,TestingUtil.getEntity(hearingDetails.getFacilitiesRequired()));
+        assertEquals(ListingMapper.WELSH_LANGUAGE_FALSE_VALUE, listing.getListingLanguage());
+    }
+
+    @Test
+    void shouldReturnListingWithWelshLanguageValue() {
+        HearingDetails hearingDetails = buildHearingDetails(150);
+        hearingDetails.setHearingInWelshFlag(true);
+        Listing listing = buildListing(hearingDetails,TestingUtil.getEntity(hearingDetails.getFacilitiesRequired()));
+        assertEquals(ListingMapper.WELSH_LANGUAGE_TRUE_VALUE, listing.getListingLanguage());
+    }
+
+    @Test
+    void shouldReturnListingJohTiersWithGivenRoleType() {
+        HearingDetails hearingDetails = buildHearingDetails(150);
+        hearingDetails.getPanelRequirements().setRoleType(List.of(RoleType.ORGANISATION.name()));
+        Listing listing = buildListing(hearingDetails,TestingUtil.getEntity(hearingDetails.getFacilitiesRequired()));
+        assertTrue(listing.getListingJohTiers().contains(RoleType.ORGANISATION.name()));
+    }
+
+    @Test
+    void shouldReturnListingOtherConsiderationWtithGivenFacilitiesRequired() {
+        List<String> faciltiesRequired = List.of("Reading Room","Study Room");
+        HearingDetails hearingDetails = buildHearingDetails(150);
+        hearingDetails.setFacilitiesRequired(faciltiesRequired);
+        Listing listing = buildListing(hearingDetails,TestingUtil.getEntity(hearingDetails.getFacilitiesRequired()));
+        faciltiesRequired.forEach(e -> {
+            assertTrue(listing.getListingOtherConsiderations().contains(e));
+        });
+    }
 
     @Test
     void shouldReturnListingWithBothHearingWindowFieldsAndRoleType() {

--- a/src/test/java/uk/gov/hmcts/reform/hmc/helper/hmi/ListingMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/hmc/helper/hmi/ListingMapperTest.java
@@ -77,6 +77,7 @@ class ListingMapperTest {
         assertEquals(4, listing.getListingNumberAttendees());
         assertEquals(LISTING_COMMENTS, listing.getListingComments());
         assertEquals(HEARING_REQUESTER, listing.getListingRequestedBy());
+        assertEquals("ENG", listing.getListingLanguage());
         assertEquals(false, listing.getListingPrivateFlag());
         assertEquals(2, listing.getListingHearingChannels().size());
         assertEquals(AMEND_REASON_CODE, listing.getAmendReasonCode());


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/HMAN-336


### Change description ###

Instead of sending a boolean listingWelshHearingFlag, we need to send listingLanguage (also at the listing level). This listingLanguage should be a string that is set to:

cym , if the hearingDetails.hearingInWelshFlag is set to true
ENG otherwise (i.e. if the hearingDetails.hearingInWelshFlag is set to false or null)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
