### PR TITLE
HMAN-329 CVE-2022-34305 tomcat upgrade 9.0.65, suppression removed

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -266,7 +266,6 @@ dependencyManagement {
       entry 'json-path'
       entry 'xml-path'
     }
-    
     dependencySet(group: 'org.apache.tomcat.embed', version: '9.0.68') {
       entry 'tomcat-embed-core'
       entry 'tomcat-embed-el'

--- a/build.gradle
+++ b/build.gradle
@@ -264,7 +264,7 @@ dependencyManagement {
       entry 'json-path'
       entry 'xml-path'
     }
-    dependencySet(group: 'org.apache.tomcat.embed', version: '9.0.63') {
+    dependencySet(group: 'org.apache.tomcat.embed', version: '9.0.65') {
       entry 'tomcat-embed-core'
       entry 'tomcat-embed-el'
       entry 'tomcat-embed-websocket'

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -16,11 +16,9 @@
       <![CDATA[Temporary suppressions pending investigation]]>
       CVE-2022-29885 refer https://tools.hmcts.net/jira/browse/HMAN-238
       CVE-2022-22971, CVE-2022-22970 refer https://tools.hmcts.net/jira/browse/HMAN-248
-      CVE-2022-34305 refer https://tools.hmcts.net/jira/browse/HMAN-329
     </notes>
     <cve>CVE-2022-22971</cve>
     <cve>CVE-2022-22970</cve>
-    <cve>CVE-2022-34305</cve>
     <cve>CVE-2022-33915</cve>
   </suppress>
 


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/HMAN-329
CVE-2022-34305 tomcat upgrade 9.0.65

### JIRA link (if applicable) ###



### Change description ###



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
