### PR TITLE
HMAN-432 Fix for CVE-2022-38752- update snakeyaml to version 1.32

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -360,6 +360,7 @@ dependencies {
   compile group: 'com.fasterxml.jackson.module', name: 'jackson-module-jaxb-annotations', version: '2.13.2'
   compile "com.fasterxml.jackson.core:jackson-databind:2.13.2.2"
   compile group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: '2.13.2'
+  compile group: 'org.yaml', name: 'snakeyaml', version: '1.32'
 
   testImplementation (group: 'com.github.hmcts', name: 'ccd-test-definitions', version: '7.13.0') {
     exclude group: 'com.github.hmcts.befta-fw', module: 'befta-fw'

--- a/build.gradle
+++ b/build.gradle
@@ -229,7 +229,8 @@ def versions = [
   springfoxSwagger: '3.0.0',
   testcontainers  : '1.15.2',
   netty           : '4.1.77.Final',
-  serviceAuthVersion: '4.0.3'
+  serviceAuthVersion: '4.0.3' ,
+  jackson           : '2.14.0-rc1'
 ]
 
 ext['spring-framework.version'] = '5.3.19'
@@ -357,9 +358,9 @@ dependencies {
   compile group: 'javax.inject', name: 'javax.inject', version: '1'
   compile group: 'io.jsonwebtoken', name: 'jjwt', version:'0.9.1'
   compile 'net.minidev:json-smart:2.4.7'
-  compile group: 'com.fasterxml.jackson.module', name: 'jackson-module-jaxb-annotations', version: '2.13.2'
-  compile "com.fasterxml.jackson.core:jackson-databind:2.13.2.2"
-  compile group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: '2.13.2'
+  compile group: 'com.fasterxml.jackson.module', name: 'jackson-module-jaxb-annotations', version: versions.jackson
+  compile "com.fasterxml.jackson.core:jackson-databind:2.14.0-rc1"
+  compile group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: versions.jackson
   compile group: 'org.yaml', name: 'snakeyaml', version: '1.32'
 
   testImplementation (group: 'com.github.hmcts', name: 'ccd-test-definitions', version: '7.13.0') {

--- a/build.gradle
+++ b/build.gradle
@@ -229,8 +229,7 @@ def versions = [
   springfoxSwagger: '3.0.0',
   testcontainers  : '1.15.2',
   netty           : '4.1.77.Final',
-  serviceAuthVersion: '4.0.3' ,
-  jackson           : '2.14.0-rc1'
+  serviceAuthVersion: '4.0.3'
 ]
 
 ext['spring-framework.version'] = '5.3.19'
@@ -358,9 +357,9 @@ dependencies {
   compile group: 'javax.inject', name: 'javax.inject', version: '1'
   compile group: 'io.jsonwebtoken', name: 'jjwt', version:'0.9.1'
   compile 'net.minidev:json-smart:2.4.7'
-  compile group: 'com.fasterxml.jackson.module', name: 'jackson-module-jaxb-annotations', version: versions.jackson
-  compile "com.fasterxml.jackson.core:jackson-databind:2.14.0-rc1"
-  compile group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: versions.jackson
+  compile group: 'com.fasterxml.jackson.module', name: 'jackson-module-jaxb-annotations', version: '2.13.2'
+  compile "com.fasterxml.jackson.core:jackson-databind:2.13.2.2"
+  compile group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: '2.13.2'
   compile group: 'org.yaml', name: 'snakeyaml', version: '1.32'
 
   testImplementation (group: 'com.github.hmcts', name: 'ccd-test-definitions', version: '7.13.0') {

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -43,20 +43,12 @@
   </suppress>
   <suppress>
     <notes>Temporary Suppression
-      CVE-2022-38751 refer https://tools.hmcts.net/jira/browse/HMAN-423
-      CVE-2022-38750 refer https://tools.hmcts.net/jira/browse/HMAN-423
-      CCVE-2022-38749 refer https://tools.hmcts.net/jira/browse/HMAN-423
-      CVE-2022-38752 refer https://tools.hmcts.net/jira/browse/HMAN-432
       CVE-2022-42003 refer https://tools.hmcts.net/jira/browse/HMAN-438
       CVE-2022-42004 refer https://tools.hmcts.net/jira/browse/HMAN-438
       CVE-2022-31690 refer https://tools.hmcts.net/jira/browse/HMAN-454
       CVE-2022-31692 refer https://tools.hmcts.net/jira/browse/HMAN-454
       CVE-2022-42252 refer https://tools.hmcts.net/jira/browse/HMAN-455
     </notes>
-    <cve>CVE-2022-38751</cve>
-    <cve>CVE-2022-38750</cve>
-    <cve>CVE-2022-38749</cve>
-    <cve>CVE-2022-38752</cve>
     <cve>CVE-2022-42003</cve>
     <cve>CVE-2022-42004</cve>
     <cve>CVE-2022-31690</cve>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -41,16 +41,6 @@
 		<cve>CVE-2022-38750</cve>
 		<cve>CVE-2022-38749</cve>
   </suppress>
-  <suppress>
-    <notes>Temporary Suppression
-      CVE-2022-38751 refer https://tools.hmcts.net/jira/browse/HMAN-423
-      CVE-2022-38750 refer https://tools.hmcts.net/jira/browse/HMAN-423
-      CVE-2022-38749 refer https://tools.hmcts.net/jira/browse/HMAN-423
-    </notes>
-    <cve>CVE-2022-38751</cve>
-    <cve>CVE-2022-38750</cve>
-    <cve>CVE-2022-38749</cve>
-  </suppress>
 
   <!--End of temporary suppression section -->
 

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -45,16 +45,11 @@
     <notes>Temporary Suppression
       CVE-2022-38751 refer https://tools.hmcts.net/jira/browse/HMAN-423
       CVE-2022-38750 refer https://tools.hmcts.net/jira/browse/HMAN-423
-      CCVE-2022-38749 refer https://tools.hmcts.net/jira/browse/HMAN-423
-      CVE-2022-42003 refer https://tools.hmcts.net/jira/browse/HMAN-438
-      CVE-2022-42004 refer https://tools.hmcts.net/jira/browse/HMAN-438
+      CVE-2022-38749 refer https://tools.hmcts.net/jira/browse/HMAN-423
     </notes>
     <cve>CVE-2022-38751</cve>
     <cve>CVE-2022-38750</cve>
     <cve>CVE-2022-38749</cve>
-    <cve>CVE-2022-42003</cve>
-    <cve>CVE-2022-42004</cve>
-
   </suppress>
 
   <!--End of temporary suppression section -->

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -46,14 +46,12 @@
       CVE-2022-38751 refer https://tools.hmcts.net/jira/browse/HMAN-423
       CVE-2022-38750 refer https://tools.hmcts.net/jira/browse/HMAN-423
       CCVE-2022-38749 refer https://tools.hmcts.net/jira/browse/HMAN-423
-      CVE-2022-38752 refer https://tools.hmcts.net/jira/browse/HMAN-432
       CVE-2022-42003 refer https://tools.hmcts.net/jira/browse/HMAN-438
       CVE-2022-42004 refer https://tools.hmcts.net/jira/browse/HMAN-438
     </notes>
     <cve>CVE-2022-38751</cve>
     <cve>CVE-2022-38750</cve>
     <cve>CVE-2022-38749</cve>
-    <cve>CVE-2022-38752</cve>
     <cve>CVE-2022-42003</cve>
     <cve>CVE-2022-42004</cve>
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/HMAN-432
https://tools.hmcts.net/jira/browse/HMAN-423


### Change description ###

HMAN-432 Fix for CVE-2022-38752- updated snakeyaml to version 1.32
HMAN-423 Fix for CVE-2022-38751 CVE-2022-38750 CVE-2022-38749 -  updated snakeyaml to version 1.32

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
