### PR TITLE
HMAN-438

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -234,7 +234,7 @@ def versions = [
 
 ext['spring-framework.version'] = '5.3.19'
 ext['log4j2.version'] = '2.17.1'
-ext['jackson.version'] = '2.13.2'
+ext['jackson.version'] = '2.13.4'
 
 // before committing a change, make sure task still works
 dependencyUpdates {
@@ -357,9 +357,9 @@ dependencies {
   compile group: 'javax.inject', name: 'javax.inject', version: '1'
   compile group: 'io.jsonwebtoken', name: 'jjwt', version:'0.9.1'
   compile 'net.minidev:json-smart:2.4.7'
-  compile group: 'com.fasterxml.jackson.module', name: 'jackson-module-jaxb-annotations', version: '2.13.2'
-  compile "com.fasterxml.jackson.core:jackson-databind:2.13.2.2"
-  compile group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: '2.13.2'
+  compile group: 'com.fasterxml.jackson.module', name: 'jackson-module-jaxb-annotations', version: '2.13.4'
+  compile "com.fasterxml.jackson.core:jackson-databind:2.13.4.2"
+  compile group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: '2.13.4'
 
   testImplementation (group: 'com.github.hmcts', name: 'ccd-test-definitions', version: '7.13.0') {
     exclude group: 'com.github.hmcts.befta-fw', module: 'befta-fw'

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -47,8 +47,6 @@
       CVE-2022-38750 refer https://tools.hmcts.net/jira/browse/HMAN-423
       CCVE-2022-38749 refer https://tools.hmcts.net/jira/browse/HMAN-423
       CVE-2022-38752 refer https://tools.hmcts.net/jira/browse/HMAN-432
-      CVE-2022-42003 refer https://tools.hmcts.net/jira/browse/HMAN-438
-      CVE-2022-42004 refer https://tools.hmcts.net/jira/browse/HMAN-438
       CVE-2022-31690 refer https://tools.hmcts.net/jira/browse/HMAN-454
       CVE-2022-31692 refer https://tools.hmcts.net/jira/browse/HMAN-454
       CVE-2022-42252 refer https://tools.hmcts.net/jira/browse/HMAN-455
@@ -57,8 +55,6 @@
     <cve>CVE-2022-38750</cve>
     <cve>CVE-2022-38749</cve>
     <cve>CVE-2022-38752</cve>
-    <cve>CVE-2022-42003</cve>
-    <cve>CVE-2022-42004</cve>
     <cve>CVE-2022-31690</cve>
     <cve>CVE-2022-31692</cve>
     <cve>CVE-2022-42252</cve>


### PR DESCRIPTION

### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/HMAN-438


### Change description ###
Fix for 
Dependency check stage of nightly build detected the following vulnerabilities in the jackson-databind dependency:

https://nvd.nist.gov/vuln/detail/CVE-2022-42003
https://nvd.nist.gov/vuln/detail/CVE-2022-42004

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
