### PR TITLE
.getProperty() changed to getenv() for pact properties

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -68,7 +68,7 @@ env.IDAM_API_URL_BASE = "https://idam-api.aat.platform.hmcts.net"
 env.S2S_URL_BASE = "http://rpe-service-auth-provider-aat.service.core-compute-aat.internal"
 env.BEFTA_S2S_CLIENT_ID = "ccd_gw"
 env.BEFTA_RESPONSE_HEADER_CHECK_POLICY="JUST_WARN"
-env.PACT_BROKER_FULL_URL = 'https://pact-broker.platform.hmcts.net'
+env.PACT_BROKER_URL = 'https://pact-broker.platform.hmcts.net'
 
 env.DEFINITION_STORE_URL_BASE = "https://ccd-definition-store-api-${definitionStoreDevelopPr}.service.core-compute-preview.internal".toLowerCase()
 

--- a/build.gradle
+++ b/build.gradle
@@ -479,7 +479,10 @@ wrapper {
 pact {
   publish {
     pactDirectory = 'build/pacts'
-    pactBrokerUrl = project.property("pact.broker.url") ?: 'http://localhost:80'
+    pactBrokerUrl = 'http://localhost:80'
+    if (hasProperty('pact.broker.url')) {
+      pactBrokerUrl = project.property("pact.broker.url")
+    }
     tags = [System.getenv("PACT_BRANCH_NAME") ?: 'Dev']
     version = '0.0.1'
   }

--- a/build.gradle
+++ b/build.gradle
@@ -479,7 +479,7 @@ wrapper {
 pact {
   publish {
     pactDirectory = 'build/pacts'
-    pactBrokerUrl = System.getenv("pact.broker.url") ?: 'http://localhost:80'
+    pactBrokerUrl = System.getenv("pact.broker.url") ?: 'https://pact-broker.platform.hmcts.net'
     tags = [System.getenv("PACT_BRANCH_NAME") ?: 'Dev']
     version = '0.0.1'
   }

--- a/build.gradle
+++ b/build.gradle
@@ -479,7 +479,7 @@ wrapper {
 pact {
   publish {
     pactDirectory = 'build/pacts'
-    pactBrokerUrl = System.getProperty("pact.broker.url") ?: 'https://pact-broker.platform.hmcts.net'
+    pactBrokerUrl = project.property("pact.broker.url") ?: 'http://localhost:80'
     tags = [System.getenv("PACT_BRANCH_NAME") ?: 'Dev']
     version = '0.0.1'
   }

--- a/build.gradle
+++ b/build.gradle
@@ -300,7 +300,7 @@ task runProviderPactVerification(type:Test) {
   useJUnitPlatform()
   testClassesDirs = sourceSets.contractTest.output.classesDirs
   classpath = sourceSets.contractTest.runtimeClasspath
-  systemProperty 'pact.verifier.publishResults', System.getProperty('pact.verifier.publishResults')
+  systemProperty 'pact.verifier.publishResults', System.getenv('pact.verifier.publishResults')
   systemProperty 'pact.provider.version', project.pactVersion
   include "uk/gov/hmcts/reform/hmc/provider/**"
   include "uk/gov/hmcts/reform/hmc/controllers/**"
@@ -479,7 +479,7 @@ wrapper {
 pact {
   publish {
     pactDirectory = 'build/pacts'
-    pactBrokerUrl = System.getProperty("pact.broker.url") ?: 'http://localhost:80'
+    pactBrokerUrl = System.getenv("pact.broker.url") ?: 'http://localhost:80'
     tags = [System.getenv("PACT_BRANCH_NAME") ?: 'Dev']
     version = '0.0.1'
   }

--- a/build.gradle
+++ b/build.gradle
@@ -300,7 +300,7 @@ task runProviderPactVerification(type:Test) {
   useJUnitPlatform()
   testClassesDirs = sourceSets.contractTest.output.classesDirs
   classpath = sourceSets.contractTest.runtimeClasspath
-  systemProperty 'pact.verifier.publishResults', System.getenv('pact.verifier.publishResults')
+  systemProperty 'pact.verifier.publishResults', System.getProperty('pact.verifier.publishResults')
   systemProperty 'pact.provider.version', project.pactVersion
   include "uk/gov/hmcts/reform/hmc/provider/**"
   include "uk/gov/hmcts/reform/hmc/controllers/**"
@@ -479,7 +479,7 @@ wrapper {
 pact {
   publish {
     pactDirectory = 'build/pacts'
-    pactBrokerUrl = System.getenv("pact.broker.url") ?: 'https://pact-broker.platform.hmcts.net'
+    pactBrokerUrl = System.getProperty("pact.broker.url") ?: 'https://pact-broker.platform.hmcts.net'
     tags = [System.getenv("PACT_BRANCH_NAME") ?: 'Dev']
     version = '0.0.1'
   }

--- a/build.gradle
+++ b/build.gradle
@@ -479,10 +479,7 @@ wrapper {
 pact {
   publish {
     pactDirectory = 'build/pacts'
-    pactBrokerUrl = 'http://localhost:80'
-    if (hasProperty('pact.broker.url')) {
-      pactBrokerUrl = project.property("pact.broker.url")
-    }
+    pactBrokerUrl = System.getenv("PACT_BROKER_URL") ?: 'http://localhost:80'
     tags = [System.getenv("PACT_BRANCH_NAME") ?: 'Dev']
     version = '0.0.1'
   }


### PR DESCRIPTION
Helping to solve https://tools.hmcts.net/jira/browse/DTSPO-11983
 Master builds failing at Pact Consumer Verification stage

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
