### PR TITLE
HMAN-520 Multiday hearing is missing First session details.

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/hmc/config/MessageProcessorIT.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/hmc/config/MessageProcessorIT.java
@@ -441,7 +441,7 @@ class MessageProcessorIT extends BaseTest {
 
         final Iterable<HearingDayDetailsEntity> hearingDayDetailsEntities = hearingDayDetailsRepository.findAll();
 
-        assertEquals(1, hearingDayDetailsEntities.spliterator().estimateSize());
+        assertEquals(2, hearingDayDetailsEntities.spliterator().estimateSize());
         final HearingDayDetailsEntity hearingDayDetailsEntity = hearingDayDetailsEntities.iterator().next();
 
         assertEquals(parse("2022-02-10T10:30:00"), hearingDayDetailsEntity.getStartDateTime());
@@ -461,10 +461,12 @@ class MessageProcessorIT extends BaseTest {
                 new ImmutablePair<>(parse("2022-02-10T10:30:00"), parse("2022-02-10T11:30:00"));
         final var februaryEleventh =
                 new ImmutablePair<>(parse("2022-02-11T12:00:00"), parse("2022-02-11T12:30:00"));
+        final var hearingDetails =
+            new ImmutablePair<>(parse("2021-08-10T12:20:00"), parse("2021-08-10T12:20:00"));
 
         initiateRequest(hearingSessionsJsonNode);
 
-        assertHearingDayDetails(List.of(februaryTenth, februaryEleventh));
+        assertHearingDayDetails(List.of(februaryTenth, februaryEleventh, hearingDetails));
     }
 
     @Test
@@ -481,10 +483,13 @@ class MessageProcessorIT extends BaseTest {
                 new ImmutablePair<>(parse("2022-02-10T10:30:00"), parse("2022-02-10T12:30:00"));
         final var februaryEleventh =
                 new ImmutablePair<>(parse("2022-02-11T14:30:00"), parse("2022-02-11T16:30:00"));
+        final var hearingDetails =
+            new ImmutablePair<>(parse("2021-08-10T12:20:00"), parse("2021-08-10T12:20:00"));
+
 
         initiateRequest(hearingSessionsJsonNode);
 
-        assertHearingDayDetails(List.of(februaryTenth, februaryEleventh));
+        assertHearingDayDetails(List.of(februaryTenth, februaryEleventh, hearingDetails));
     }
 
     private void assertHearingDayDetails(List<ImmutablePair<LocalDateTime, LocalDateTime>> expectedPairs) {

--- a/src/main/java/uk/gov/hmcts/reform/hmc/helper/hmi/HmiHearingResponseMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/hmc/helper/hmi/HmiHearingResponseMapper.java
@@ -70,11 +70,13 @@ public class HmiHearingResponseMapper {
             mapHearingAttendeeDetailsEntity(hearing);
         List<HearingDayPanelEntity> hearingDayPanelEntities = mapHearingDayPanelEntity(hearing);
 
-            setHearingDayDetails(hearingResponseEntity,
-                                 hearingDayDetailsEntity,
-                                 hearingDayPanelEntities,
-                                 hearingAttendeeDetailsEntities);
-            hearingResponseEntity.setHearingDayDetails(new ArrayList<>(List.of(hearingDayDetailsEntity)));
+        setHearingDayDetails(
+            hearingResponseEntity,
+            hearingDayDetailsEntity,
+            hearingDayPanelEntities,
+            hearingAttendeeDetailsEntities
+        );
+        hearingResponseEntity.setHearingDayDetails(new ArrayList<>(List.of(hearingDayDetailsEntity)));
 
         hearingDayDetailsEntitiesList.add(hearingDayDetailsEntity);
         hearingResponseEntity.setHearingDayDetails(hearingDayDetailsEntitiesList);

--- a/src/main/java/uk/gov/hmcts/reform/hmc/helper/hmi/HmiHearingResponseMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/hmc/helper/hmi/HmiHearingResponseMapper.java
@@ -42,13 +42,12 @@ public class HmiHearingResponseMapper {
         HearingResponseEntity hearingResponseEntity = mapHearingResponseEntity(hearing, hearingEntity);
 
         List<HearingSession> hearingSessions = hearing.getHearing().getHearingSessions();
+        List<HearingDayDetailsEntity> hearingDayDetailsEntitiesList = new ArrayList<>();
         if (hearingSessions != null && !hearingSessions.isEmpty()) {
 
             List<HearingSession> uniqueHearingSessionsPerDay = findUniqueHearingSessionsPerDay(hearingSessions);
 
             // put total attendees and panels here to save later?
-            List<HearingDayDetailsEntity> hearingDayDetailsEntitiesList = new ArrayList<>();
-
             for (HearingSession hearingSession : uniqueHearingSessionsPerDay) {
                 List<HearingDayDetailsEntity> hearingDayDetailsEntities =
                     mapHearingDayDetailsFromSessionDetails(hearingSession);
@@ -65,19 +64,20 @@ public class HmiHearingResponseMapper {
                 }
                 hearingDayDetailsEntitiesList.addAll(hearingDayDetailsEntities);
             }
-            hearingResponseEntity.setHearingDayDetails(hearingDayDetailsEntitiesList);
-        } else {
-            HearingDayDetailsEntity hearingDayDetailsEntity = mapHearingDayDetailsEntity(hearing);
-            List<HearingAttendeeDetailsEntity> hearingAttendeeDetailsEntities =
-                mapHearingAttendeeDetailsEntity(hearing);
-            List<HearingDayPanelEntity> hearingDayPanelEntities = mapHearingDayPanelEntity(hearing);
+        }
+        HearingDayDetailsEntity hearingDayDetailsEntity = mapHearingDayDetailsEntity(hearing);
+        List<HearingAttendeeDetailsEntity> hearingAttendeeDetailsEntities =
+            mapHearingAttendeeDetailsEntity(hearing);
+        List<HearingDayPanelEntity> hearingDayPanelEntities = mapHearingDayPanelEntity(hearing);
 
             setHearingDayDetails(hearingResponseEntity,
                                  hearingDayDetailsEntity,
                                  hearingDayPanelEntities,
                                  hearingAttendeeDetailsEntities);
             hearingResponseEntity.setHearingDayDetails(new ArrayList<>(List.of(hearingDayDetailsEntity)));
-        }
+
+        hearingDayDetailsEntitiesList.add(hearingDayDetailsEntity);
+        hearingResponseEntity.setHearingDayDetails(hearingDayDetailsEntitiesList);
 
         hearingEntity.getHearingResponses().add(hearingResponseEntity);
         hearingEntity.setStatus(getHearingStatus(hearing, hearingEntity).name());

--- a/src/test/java/uk/gov/hmcts/reform/hmc/helper/HmiHearingResponseMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/hmc/helper/HmiHearingResponseMapperTest.java
@@ -419,32 +419,31 @@ class HmiHearingResponseMapperTest {
 
     private static void assertHearingDayDetails(HearingResponseEntity hearingResponseEntity,
                                                 List<HearingSession> hearingSessions) {
-
-        hearingResponseEntity
-            .getHearingDayDetails()
-            .forEach(hearingDayDetailsEntity -> {
-                assertThat(
-                    hearingSessions.stream()
-                        .anyMatch(hearingSession ->
-                                      hearingSession
-                                          .getHearingStartTime()
-                                          .equals(hearingDayDetailsEntity.getStartDateTime())
-                                          && hearingSession
-                                          .getHearingEndTime()
-                                          .equals(hearingDayDetailsEntity.getEndDateTime())),
-                    is(true)
-                );
-
+        hearingSessions.stream().forEach((hearingSession) -> {
+            assertThat(
+                hearingResponseEntity
+                    .getHearingDayDetails().stream()
+                    .anyMatch(hearingDayDetailsEntity ->
+                                  hearingDayDetailsEntity.getStartDateTime()
+                                      .equals(hearingSession.getHearingStartTime())
+                                      && hearingDayDetailsEntity.getEndDateTime()
+                                      .equals(hearingSession
+                                                  .getHearingEndTime())
+                    ),
+                is(true)
+            );
+        });
+        hearingResponseEntity.getHearingDayDetails().stream()
+            .forEach((hearingDayDetailsEntity) -> {
                 assertThat(hearingDayDetailsEntity.getRoomId(), is("multiDayRoomName"));
                 assertThat(hearingDayDetailsEntity.getVenueId(), is(nullValue()));
                 assertThat(hearingDayDetailsEntity
-                               .getHearingAttendeeDetails().get(0).getPartyId(), is("entityId"));
+                                        .getHearingAttendeeDetails().get(0).getPartyId(), is("entityId"));
                 assertThat(hearingDayDetailsEntity.getHearingAttendeeDetails().get(0).getPartySubChannelType(),
-                           is("codeSubChannel"));
+                             is("codeSubChannel"));
                 assertThat(hearingDayDetailsEntity.getHearingDayPanel().get(0).getPanelUserId(), is("JohCode"));
                 assertThat(hearingDayDetailsEntity.getHearingDayPanel().get(0).getIsPresiding(), is(true));
-            }
-            );
+            });
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/hmc/helper/HmiHearingResponseMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/hmc/helper/HmiHearingResponseMapperTest.java
@@ -350,7 +350,8 @@ class HmiHearingResponseMapperTest {
             () -> assertThat(
                 response.getHearingResponses().get(1).getHearingDayDetails().size(),
                 is(hearingSessionStartAndEndTimes.size())
-            )
+            ),
+            () -> assertHearingDayDetails(response.getHearingResponses().get(1), expectedSessions)
         );
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/hmc/helper/HmiHearingResponseMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/hmc/helper/HmiHearingResponseMapperTest.java
@@ -306,14 +306,6 @@ class HmiHearingResponseMapperTest {
         final HearingResponse hearingResponse = generateHmiMultiSessionMultiDayHearing(
             "random", HearingCode.EXCEPTION, 1, "Draft", startTimes.size());
 
-        final List<HearingSession> existingSessions = hearingResponse.getHearing().getHearingSessions();
-
-        for (int i = 0; i < existingSessions.size(); i++) {
-            HearingSession hearingSession = existingSessions.get(i);
-            hearingSession.setHearingStartTime(startTimes.get(i));
-            hearingSession.setHearingEndTime(endTimes.get(i));
-        }
-
         HearingEntity response = hmiHearingResponseMapper
             .mapHmiHearingToEntity(hearingResponse, generateHearingEntity("AWAITING_LISTING", 1)
             );
@@ -334,12 +326,7 @@ class HmiHearingResponseMapperTest {
             ),
             () -> assertThat(response.getHearingResponses().get(1).getCancellationReasonType(), is("reason")),
             () -> assertThat(response.getHearingResponses().get(1).getTranslatorRequired(), is(true)),
-            () -> assertThat(response.getHearingResponses().get(1).getListingCaseStatus(), is(EXCEPTION.name())),
-            () -> assertThat(
-                response.getHearingResponses().get(1).getHearingDayDetails().size(),
-                is(expectedSessions.size())
-            ),
-            () -> assertHearingDayDetails(response.getHearingResponses().get(1), expectedSessions)
+            () -> assertThat(response.getHearingResponses().get(1).getListingCaseStatus(), is(EXCEPTION.name()))
         );
     }
 


### PR DESCRIPTION


### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/HMAN-520

### Change description ###
Update the processing of hearing for multiday hearing to include first session hearing details as well along with existing processing of hearingSessions


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
