### PR TITLE
HMAN-524 Upgrade dependencies to resolve CVE-2023-24998

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -229,7 +229,7 @@ def versions = [
   testcontainers  : '1.15.2',
   netty           : '4.1.86.Final',
   serviceAuthVersion: '4.0.3',
-  tomcatEmbedded  : '9.0.69'
+  tomcatEmbedded  : '9.0.73'
 ]
 
 ext['spring-framework.version'] = '5.3.24'
@@ -424,7 +424,7 @@ dependencies {
   implementation group: 'io.projectreactor.netty', name: 'reactor-netty-core', version: '1.1.0'
   implementation group: 'io.projectreactor.netty', name: 'reactor-netty-http', version: '1.1.0'
 
-  // CVE-2021-29425
+  implementation group: 'commons-fileupload', name: 'commons-fileupload', version: '1.5'
   implementation group: 'commons-io', name: 'commons-io', version: '2.8.0'
   testImplementation libraries.junit5
   testImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-test', {

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
   <suppress>
     <notes>Temporary Suppression
-        CVE-2022-45688 refer [Ticket]
-        CVE-2023-24998 refer [Ticket]</notes>
+        CVE-2022-45688 refer [Ticket]</notes>
     <cve>CVE-2022-45688</cve>
-    <cve>CVE-2023-24998</cve>
   </suppress>
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/HMAN-524


### Change description ###
Upgrade tomcat and commons-fileupload  to resolve CVE-2023-24998

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
