### PR TITLE
CCD-4845: renovate config

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,5 +1,0 @@
-version: 1
-update_configs:
-  - package_manager: "java:gradle"
-    directory: "/"
-    update_schedule: "daily"

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,7 @@
 {
   "enabledManagers": ["helm-requirements","gradle-wrapper","terraform"],
   "labels": ["dependencies"],
+  "extends": ["local>hmcts/.github:renovate-config"],
   "helm-requirements":
   {
     "fileMatch": ["\\Chart.yaml$"],

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,6 @@
 {
   "enabledManagers": ["helm-requirements","gradle-wrapper","terraform"],
-  "labels": ["dependencies"],
+  "labels": ["Renovate-dependencies"],
   "extends": ["local>hmcts/.github:renovate-config"],
   "helm-requirements":
   {

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,12 +1,19 @@
 {
-  "enabledManagers": ["helm-requirements","gradle-wrapper","terraform"],
-  "labels": ["Renovate-dependencies"],
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["local>hmcts/.github:renovate-config"],
-  "helm-requirements":
-  {
-    "fileMatch": ["\\Chart.yaml$"],
-    "aliases": {
-      "hmctspublic": "https://hmctspublic.azurecr.io/helm/v1/repo/"
+  "labels": ["Renovate-dependencies"],
+  "major": {
+    "dependencyDashboardApproval": true
+  },
+  "packageRules": [
+    {
+      "matchUpdateTypes": [
+        "minor", "patch"
+      ],
+      "groupName": "All patch-minor dependencies",
+      "groupSlug": "All-minor-patch",
+      "addLabels": ["Renovate All-minor-patch"],
+      "automerge": false
     }
-  }
+  ]
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/CCD-4845

### Change description ###

Renovate config is now mandatory in every repo extending default org level config without using enabledManagers. 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
