### PR TITLE
HMAN 598: Second update to a previously listed hearing gives a 500 error

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ plugins {
   id 'uk.gov.hmcts.java' version '0.12.43'
   id 'com.github.spacialcircumstances.gradle-cucumber-reporting' version '0.1.23'
   id 'au.com.dius.pact' version '4.1.7'
-  id 'com.github.hmcts.rse-cft-lib' version '0.19.169'
+  id 'com.github.hmcts.rse-cft-lib' version '0.19.958'
 }
 
 ext['diuspactproviderVersion'] = '4.2.14'

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ plugins {
   id 'uk.gov.hmcts.java' version '0.12.43'
   id 'com.github.spacialcircumstances.gradle-cucumber-reporting' version '0.1.23'
   id 'au.com.dius.pact' version '4.1.7'
-  id 'com.github.hmcts.rse-cft-lib' version '0.19.958'
+  id 'com.github.hmcts.rse-cft-lib' version '0.19.963'
 }
 
 ext['diuspactproviderVersion'] = '4.2.14'

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -230,7 +230,6 @@
                 value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF, VARIABLE_DEF"/>
     </module>
     <module name="JavadocMethod">
-      <property name="scope" value="nothing"/>
       <property name="allowMissingParamTags" value="true"/>
       <property name="allowMissingReturnTag" value="true"/>
       <property name="allowedAnnotations" value="Override, Test"/>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -37,5 +37,7 @@
     <cve>CVE-2023-45960</cve>
     <cve>CVE-2023-33202</cve>
     <cve>CVE-2023-46589</cve>
+    <cve>CVE-2023-6378</cve>
+    <cve>CVE-2023-35116</cve>
   </suppress>
 </suppressions>

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/uk/gov/hmcts/reform/hmc/controllers/HearingManagementController.java
+++ b/src/main/java/uk/gov/hmcts/reform/hmc/controllers/HearingManagementController.java
@@ -95,7 +95,7 @@ public class HearingManagementController {
                 + "\n1) " + ValidationError.INVALID_HEARING_REQUEST_DETAILS
                 + "\n2) " + ValidationError.HEARING_WINDOW_DETAILS_ARE_INVALID
                 + "\n3) " + ValidationError.INVALID_ORG_INDIVIDUAL_DETAILS
-        )
+            )
     })
     public HearingResponse saveHearing(@RequestHeader(value = HMCTS_DEPLOYMENT_ID, required = false)
                                         String deploymentId,
@@ -139,7 +139,7 @@ public class HearingManagementController {
                 + "\n2) " + ValidationError.CASE_REF_EMPTY
                 + "\n3) " + ValidationError.CASE_REF_INVALID_LENGTH
                 + "\n4) " + ValidationError.CASE_REF_INVALID
-        )
+            )
     })
     public GetHearingsResponse getHearings(@PathVariable("ccdCaseRef") @Valid
                                            @NotEmpty(message = ValidationError.CASE_REF_EMPTY)

--- a/src/main/java/uk/gov/hmcts/reform/hmc/data/HearingResponseEntity.java
+++ b/src/main/java/uk/gov/hmcts/reform/hmc/data/HearingResponseEntity.java
@@ -11,6 +11,7 @@ import java.io.Serializable;
 import java.time.LocalDateTime;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
@@ -90,7 +91,7 @@ public class HearingResponseEntity extends BaseEntity implements Serializable {
     private String listingTransactionId;
 
     public Optional<HearingDayDetailsEntity> getEarliestHearingDayDetails() {
-        return getHearingDayDetails().stream()
+        return getHearingDayDetails().stream().filter(Objects::nonNull)
             .min(Comparator.comparing(HearingDayDetailsEntity::getStartDateTime));
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/hmc/data/HearingResponseEntity.java
+++ b/src/main/java/uk/gov/hmcts/reform/hmc/data/HearingResponseEntity.java
@@ -11,7 +11,6 @@ import java.io.Serializable;
 import java.time.LocalDateTime;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import javax.persistence.CascadeType;
 import javax.persistence.Column;

--- a/src/main/java/uk/gov/hmcts/reform/hmc/data/HearingResponseEntity.java
+++ b/src/main/java/uk/gov/hmcts/reform/hmc/data/HearingResponseEntity.java
@@ -91,7 +91,7 @@ public class HearingResponseEntity extends BaseEntity implements Serializable {
     private String listingTransactionId;
 
     public Optional<HearingDayDetailsEntity> getEarliestHearingDayDetails() {
-        return getHearingDayDetails().stream().filter(Objects::nonNull)
+        return getHearingDayDetails().stream().filter(h -> h.getStartDateTime() != null)
             .min(Comparator.comparing(HearingDayDetailsEntity::getStartDateTime));
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/hmc/validator/LinkedHearingValidator.java
+++ b/src/main/java/uk/gov/hmcts/reform/hmc/validator/LinkedHearingValidator.java
@@ -366,8 +366,8 @@ public class LinkedHearingValidator {
         if (log.isDebugEnabled()) {
             if (hearingResponse.isPresent()) {
                 log.debug("hearing response: {} : {}",
-                          hearingResponse.get().getHearingResponseId(),
-                          hearingResponse.get().getRequestTimeStamp());
+                        hearingResponse.get().getHearingResponseId(),
+                        hearingResponse.get().getRequestTimeStamp());
             } else {
                 log.debug("No hearing response found");
             }

--- a/src/main/java/uk/gov/hmcts/reform/hmc/validator/LinkedHearingValidator.java
+++ b/src/main/java/uk/gov/hmcts/reform/hmc/validator/LinkedHearingValidator.java
@@ -366,8 +366,8 @@ public class LinkedHearingValidator {
         if (log.isDebugEnabled()) {
             if (hearingResponse.isPresent()) {
                 log.debug("hearing response: {} : {}",
-                        hearingResponse.get().getHearingResponseId(),
-                        hearingResponse.get().getRequestTimeStamp());
+                          hearingResponse.get().getHearingResponseId(),
+                          hearingResponse.get().getRequestTimeStamp());
             } else {
                 log.debug("No hearing response found");
             }
@@ -383,9 +383,10 @@ public class LinkedHearingValidator {
         Optional<HearingDayDetailsEntity> hearingDayDetails = hearingResponse.getEarliestHearingDayDetails();
         if (log.isDebugEnabled()) {
             if (hearingDayDetails.isPresent()) {
-                log.debug("hearing day details: {} : {}",
+                log.debug("hearing day details: {} : {} : {}",
                         hearingDayDetails.get().getHearingDayId(),
-                        hearingDayDetails.get().getStartDateTime());
+                        hearingDayDetails.get().getStartDateTime(),
+                        hearingResponse.getListingStatus());
             } else {
                 log.debug("No hearing day details found");
             }

--- a/src/main/java/uk/gov/hmcts/reform/hmc/validator/LinkedHearingValidator.java
+++ b/src/main/java/uk/gov/hmcts/reform/hmc/validator/LinkedHearingValidator.java
@@ -397,7 +397,9 @@ public class LinkedHearingValidator {
                 LocalDateTime startDateTime = details.getStartDateTime();
                 if (startDateTime != null) {
                     return startDateTime.toLocalDate();
-                } else return null;
+                } else {
+                    return null;
+                }
             })
             .orElse(null);
     }

--- a/src/main/java/uk/gov/hmcts/reform/hmc/validator/LinkedHearingValidator.java
+++ b/src/main/java/uk/gov/hmcts/reform/hmc/validator/LinkedHearingValidator.java
@@ -393,11 +393,13 @@ public class LinkedHearingValidator {
         }
 
         return hearingDayDetails
-                .orElseThrow(() -> new BadRequestException(
-                        INVALID_STATE_FOR_HEARING_REQUEST
-                                .replace(HEARING_ID_PLACEHOLDER, hearingResponse.getHearing().getId().toString())
-                                + " valid hearingDayDetails not found"))
-                .getStartDateTime().toLocalDate();
+            .map(details -> {
+                LocalDateTime startDateTime = details.getStartDateTime();
+                if (startDateTime != null) {
+                    return startDateTime.toLocalDate();
+                } else return null;
+            })
+            .orElse(null);
     }
 
     public void validateHearingActualsStatus(Long hearingId, String errorMessage) {

--- a/src/test/java/uk/gov/hmcts/reform/hmc/controllers/PartiesNotifiedControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/hmc/controllers/PartiesNotifiedControllerTest.java
@@ -47,7 +47,7 @@ import static org.springframework.context.annotation.FilterType.ASSIGNABLE_TYPE;
 @ExtendWith(SpringExtension.class)
 @WebMvcTest(controllers = PartiesNotifiedController.class,
         excludeFilters = @ComponentScan.Filter(type = ASSIGNABLE_TYPE, classes =
-                {SecurityConfiguration.class, JwtGrantedAuthoritiesConverter.class}))
+            {SecurityConfiguration.class, JwtGrantedAuthoritiesConverter.class}))
 @AutoConfigureMockMvc(addFilters = false)
 @ImportAutoConfiguration(TestIdamConfiguration.class)
 class PartiesNotifiedControllerTest extends PartiesNotifiedCommonGeneration {

--- a/src/test/java/uk/gov/hmcts/reform/hmc/data/HearingEntityTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/hmc/data/HearingEntityTest.java
@@ -217,13 +217,13 @@ class HearingEntityTest {
 
         @Test
         void shouldGetEarliestHearingDayDetailsIgnoringNullStartDates() {
-            HearingResponseEntity hearingResponse = new HearingResponseEntity();
             HearingDayDetailsEntity dayDetails1 = new HearingDayDetailsEntity();
             dayDetails1.setStartDateTime(LocalDateTime.of(2023, 1, 2, 10, 0));
             HearingDayDetailsEntity dayDetails2 = new HearingDayDetailsEntity();
             dayDetails2.setStartDateTime(null);
             HearingDayDetailsEntity dayDetails3 = new HearingDayDetailsEntity();
             dayDetails3.setStartDateTime(LocalDateTime.of(2023, 1, 1, 10, 0));
+            HearingResponseEntity hearingResponse = new HearingResponseEntity();
             hearingResponse.setHearingDayDetails(List.of(dayDetails1, dayDetails2, dayDetails3));
 
             Optional<HearingDayDetailsEntity> earliest = hearingResponse.getEarliestHearingDayDetails();

--- a/src/test/java/uk/gov/hmcts/reform/hmc/data/HearingEntityTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/hmc/data/HearingEntityTest.java
@@ -247,8 +247,6 @@ class HearingEntityTest {
         }
     }
 
-
-
     @Nested
     class GetDerivedHearingResponse {
 

--- a/src/test/java/uk/gov/hmcts/reform/hmc/data/HearingEntityTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/hmc/data/HearingEntityTest.java
@@ -212,6 +212,42 @@ class HearingEntityTest {
         }
     }
 
+    @Nested
+    class GetEarliestHearingDayDetails {
+
+        @Test
+        void shouldGetEarliestHearingDayDetailsIgnoringNullStartDates() {
+            HearingResponseEntity hearingResponse = new HearingResponseEntity();
+            HearingDayDetailsEntity dayDetails1 = new HearingDayDetailsEntity();
+            dayDetails1.setStartDateTime(LocalDateTime.of(2023, 1, 2, 10, 0));
+            HearingDayDetailsEntity dayDetails2 = new HearingDayDetailsEntity();
+            dayDetails2.setStartDateTime(null);
+            HearingDayDetailsEntity dayDetails3 = new HearingDayDetailsEntity();
+            dayDetails3.setStartDateTime(LocalDateTime.of(2023, 1, 1, 10, 0));
+            hearingResponse.setHearingDayDetails(List.of(dayDetails1, dayDetails2, dayDetails3));
+
+            Optional<HearingDayDetailsEntity> earliest = hearingResponse.getEarliestHearingDayDetails();
+
+            assertTrue(earliest.isPresent());
+            assertEquals(dayDetails3.getStartDateTime(), earliest.get().getStartDateTime());
+        }
+
+        @Test
+        void shouldReturnEmptyIfAllStartDatesAreNull() {
+            HearingResponseEntity hearingResponse = new HearingResponseEntity();
+            HearingDayDetailsEntity dayDetails1 = new HearingDayDetailsEntity();
+            dayDetails1.setStartDateTime(null);
+            HearingDayDetailsEntity dayDetails2 = new HearingDayDetailsEntity();
+            dayDetails2.setStartDateTime(null);
+            hearingResponse.setHearingDayDetails(List.of(dayDetails1, dayDetails2));
+
+            Optional<HearingDayDetailsEntity> earliest = hearingResponse.getEarliestHearingDayDetails();
+
+            assertFalse(earliest.isPresent());
+        }
+    }
+
+
 
     @Nested
     class GetDerivedHearingResponse {

--- a/src/test/java/uk/gov/hmcts/reform/hmc/validator/CapitalizedEnumPatternValidatorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/hmc/validator/CapitalizedEnumPatternValidatorTest.java
@@ -28,7 +28,7 @@ class CapitalizedEnumPatternValidatorTest {
 
     @ParameterizedTest
     @ValueSource(strings = {"MONDAY", "TUESDAY", "WEDNESDAY", "THURSDAY", "FRIDAY", "SATURDAY", "SUNDAY", "MoNdAy",
-            "TUEsday", "wednesday", "THuRSDAY", "FridaY", "saturday", "sUNDAY"})
+        "TUEsday", "wednesday", "THuRSDAY", "FridaY", "saturday", "sUNDAY"})
     void whenInvalidCaseUnavailabilityDow(String dowValue) {
         final Set<ConstraintViolation<UnavailabilityDow>> violations =
                 createAndValidateUnavailabilityDow(dowValue);

--- a/src/test/java/uk/gov/hmcts/reform/hmc/validator/LinkedHearingValidatorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/hmc/validator/LinkedHearingValidatorTest.java
@@ -42,6 +42,7 @@ import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -1179,6 +1180,36 @@ class LinkedHearingValidatorTest {
             linkedHearingValidator.validateHearingLinkGroupRequest(hearingLinkGroupRequest, null);
         });
         assertEquals("003 hearing request already in a group", exception.getMessage());
+    }
+
+    @Test
+    void shouldReturnNullIfNoHearingDayDetailsWithNonNullStartDates() {
+        HearingResponseEntity hearingResponse = new HearingResponseEntity();
+        HearingDayDetailsEntity dayDetails1 = new HearingDayDetailsEntity();
+        dayDetails1.setStartDateTime(null);
+        HearingDayDetailsEntity dayDetails2 = new HearingDayDetailsEntity();
+        dayDetails2.setStartDateTime(null);
+        hearingResponse.setHearingDayDetails(List.of(dayDetails1, dayDetails2));
+
+        LocalDate result = linkedHearingValidator.getLowestDate(hearingResponse);
+
+        assertNull(result);
+    }
+
+    @Test
+    void shouldReturnEarliestDateIgnoringNullStartDates() {
+        HearingDayDetailsEntity dayDetails1 = new HearingDayDetailsEntity();
+        dayDetails1.setStartDateTime(LocalDateTime.of(2023, 1, 2, 10, 0));
+        HearingDayDetailsEntity dayDetails2 = new HearingDayDetailsEntity();
+        dayDetails2.setStartDateTime(null);
+        HearingDayDetailsEntity dayDetails3 = new HearingDayDetailsEntity();
+        dayDetails3.setStartDateTime(LocalDateTime.of(2023, 1, 1, 10, 0));
+        HearingResponseEntity hearingResponse = new HearingResponseEntity();
+        hearingResponse.setHearingDayDetails(List.of(dayDetails1, dayDetails2, dayDetails3));
+
+        LocalDate result = linkedHearingValidator.getLowestDate(hearingResponse);
+
+        assertEquals(dayDetails3.getStartDateTime().toLocalDate(), result);
     }
 
     private List<HearingEntity> generateLinkedHearingDetailsListWithBadStatus(LinkedGroupDetails groupDetails) {


### PR DESCRIPTION
**Before creating a pull request make sure that:**

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/HMAN-598

### Change description ###

src/main/java/uk/gov/hmcts/reform/hmc/data/HearingResponseEntity.java
has the change required to prevent the null error.

other changes are bumping cftlib and style fixes


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
