### PR TITLE
Adding another resource which requires importing

### DIFF
--- a/infrastructure/import.tf
+++ b/infrastructure/import.tf
@@ -2,3 +2,8 @@ import {
   id = "/subscriptions/1c4f0704-a29e-403d-b719-b90c34ef14c9/resourceGroups/hmc-cft-hearing-service-postgres-db-v15-data-aat"
   to = module.postgresql_v15_replica[0].azurerm_resource_group.rg[0]
 }
+
+import {
+  id = "/subscriptions/1c4f0704-a29e-403d-b719-b90c34ef14c9/resourceGroups/hmc-cft-hearing-service-postgres-db-v15-data-aat/providers/Microsoft.DBforPostgreSQL/flexibleServers/hmc-cft-hearing-service-postgres-db-v15-aat"
+  to = module.postgresql_v15_replica[0].azurerm_postgresql_flexible_server.pgsql_server
+}


### PR DESCRIPTION


### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CCD-5139


### Change description ###

https://[build.hmcts.net/view/CDM/job/HMCTS_d_to_i/job/hmc-cft-hearing-service/job/master/323/pipeline-console/log?nodeId=284](https://build.hmcts.net/view/CDM/job/HMCTS_d_to_i/job/hmc-cft-hearing-service/job/master/323/pipeline-console/log?nodeId=284)

Adding another import reference based on the following pipeline error: 
A resource with the ID "/subscriptions/****/resourceGroups/hmc-cft-hearing-service-postgres-db-v15-data-aat/providers/Microsoft.DBforPostgreSQL/flexibleServers/hmc-cft-hearing-service-postgres-db-v15-aat" already exists - to be managed via Terraform this resource needs to be imported into the State. Please see the resource documentation for "azurerm_postgresql_flexible_server"
with module.postgresql_v15_replica[0].azurerm_postgresql_flexible_server.pgsql_server,
.terraform/modules/postgresql_v15_replica/pgsql-flexible-server.tf line 57, in resource "azurerm_postgresql_flexible_server" "pgsql_server":
resource "azurerm_postgresql_flexible_server" "pgsql_server"


