### PR TITLE
HMAN-888 correct responseCode to 200 OK (not 204 NO_CONTENT) when hea…

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/hmc/controllers/HearingActualsController.java
+++ b/src/main/java/uk/gov/hmcts/reform/hmc/controllers/HearingActualsController.java
@@ -33,10 +33,9 @@ public class HearingActualsController {
 
     @GetMapping(path = "/hearingActuals/{id}", produces = APPLICATION_JSON_VALUE)
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    @ApiResponse(responseCode = "204", description = "Hearing id is valid")
-    @ApiResponse(responseCode = "404", description = ValidationError.HEARING_ID_NOT_FOUND)
+    @ApiResponse(responseCode = "200", description = "Hearing id is valid")
     @ApiResponse(responseCode = "400", description = ValidationError.INVALID_HEARING_ID_DETAILS)
-
+    @ApiResponse(responseCode = "404", description = ValidationError.HEARING_ID_NOT_FOUND)
     public ResponseEntity<HearingActualResponse> getHearingActuals(@PathVariable("id") Long hearingId) {
         accessControlService.verifyHearingCaseAccess(hearingId, Lists.newArrayList(
                 HEARING_VIEWER,

--- a/src/test/java/uk/gov/hmcts/reform/hmc/controllers/HearingActualsControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/hmc/controllers/HearingActualsControllerTest.java
@@ -11,19 +11,24 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 import uk.gov.hmcts.reform.hmc.TestIdamConfiguration;
 import uk.gov.hmcts.reform.hmc.config.SecurityConfiguration;
+import uk.gov.hmcts.reform.hmc.model.hearingactuals.HearingActualResponse;
 import uk.gov.hmcts.reform.hmc.security.JwtGrantedAuthoritiesConverter;
 import uk.gov.hmcts.reform.hmc.service.AccessControlService;
 import uk.gov.hmcts.reform.hmc.service.HearingActualsServiceImpl;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static org.springframework.context.annotation.FilterType.ASSIGNABLE_TYPE;
 
 @ExtendWith(SpringExtension.class)
@@ -46,6 +51,9 @@ class HearingActualsControllerTest {
     @MockBean
     private AccessControlService accessControlService;
 
+    @MockBean
+    ResponseEntity<HearingActualResponse> response;
+
     @BeforeEach
     public void setUp() {
         mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext).build();
@@ -58,7 +66,11 @@ class HearingActualsControllerTest {
         void shouldReturn200_whenRequestIdIsValid() {
             HearingActualsController controller = new HearingActualsController(hearingActualsService,
                                                                                accessControlService);
-            controller.getHearingActuals(1234L);
+            when(hearingActualsService.getHearingActuals(1234L)).thenReturn(response);
+            when(response.getStatusCode()).thenReturn(HttpStatus.OK);
+
+            response = controller.getHearingActuals(1234L);
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
             verify(hearingActualsService, times(1)).getHearingActuals(any());
         }
     }

--- a/src/test/java/uk/gov/hmcts/reform/hmc/controllers/HearingManagementControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/hmc/controllers/HearingManagementControllerTest.java
@@ -23,6 +23,7 @@ import uk.gov.hmcts.reform.hmc.ApplicationParams;
 import uk.gov.hmcts.reform.hmc.TestIdamConfiguration;
 import uk.gov.hmcts.reform.hmc.config.SecurityConfiguration;
 import uk.gov.hmcts.reform.hmc.data.SecurityUtils;
+import uk.gov.hmcts.reform.hmc.domain.model.enums.HearingStatus;
 import uk.gov.hmcts.reform.hmc.domain.model.enums.PutHearingStatus;
 import uk.gov.hmcts.reform.hmc.model.CaseDetails;
 import uk.gov.hmcts.reform.hmc.model.DeleteHearingRequest;
@@ -39,8 +40,7 @@ import uk.gov.hmcts.reform.hmc.utils.TestingUtil;
 
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.doReturn;
@@ -91,7 +91,6 @@ class HearingManagementControllerTest {
         hearingStatusAuditService.saveAuditTriageDetailsWithCreatedDate(any(),any(),any(),any(),any(),any(),any());
         hearingStatusAuditService.saveAuditTriageDetailsWithUpdatedDate(any(),any(),any(),any(),any(),any(),any());
     }
-
 
     @Nested
     @DisplayName("saveHearing")
@@ -258,8 +257,8 @@ class HearingManagementControllerTest {
                                                                                      applicationParams,securityUtils);
             GetHearingsResponse hearingRequest = controller.getHearings(validCaseRef, null);
             verify(hearingManagementService, times(1)).getHearings(any(), any());
-            assertEquals(hearingRequest.getCaseRef(), validCaseRef);
-            assertTrue(hearingRequest.getCaseHearings().get(0).getHearingIsLinkedFlag());
+            assertThat(hearingRequest.getCaseRef()).isEqualTo(validCaseRef);
+            assertThat(hearingRequest.getCaseHearings().getFirst().getHearingIsLinkedFlag()).isTrue();
         }
 
         @Test
@@ -278,9 +277,9 @@ class HearingManagementControllerTest {
                                                                                      applicationParams, securityUtils);
             GetHearingsResponse hearingRequest = controller.getHearings(validCaseRef, null);
             verify(hearingManagementService, times(1)).getHearings(validCaseRef, "LISTED");
-            assertEquals(hearingRequest.getCaseRef(), validCaseRef);
-            assertEquals("LISTED", hearingRequest.getCaseHearings().get(0).getHmcStatus());
-            assertTrue(hearingRequest.getCaseHearings().get(0).getHearingIsLinkedFlag());
+            assertThat(hearingRequest.getCaseRef()).isEqualTo(validCaseRef);
+            assertThat(hearingRequest.getCaseHearings().getFirst().getHmcStatus()).isEqualTo("LISTED");
+            assertThat(hearingRequest.getCaseHearings().getFirst().getHearingIsLinkedFlag()).isTrue();
         }
 
         @Test
@@ -295,8 +294,8 @@ class HearingManagementControllerTest {
                                                                                      applicationParams, securityUtils);
             GetHearingsResponse hearingRequest = controller.getHearings(validCaseRef, status);
             verify(hearingManagementService, times(1)).getEmptyHearingsResponse(validCaseRef);
-            assertEquals(hearingRequest.getCaseRef(), validCaseRef);
-            assertTrue(hearingRequest.getCaseHearings().get(0).getHearingIsLinkedFlag());
+            assertThat(hearingRequest.getCaseRef()).isEqualTo(validCaseRef);
+            assertThat(hearingRequest.getCaseHearings().getFirst().getHearingIsLinkedFlag()).isTrue();
         }
     }
 
@@ -364,7 +363,8 @@ class HearingManagementControllerTest {
         @Test
         void shouldReturnHearingResponseForListed() {
             List<String> ccdCaseRefs  = List.of("9372710950276233");
-            doReturn(TestingUtil.getHearingsResponseWhenDataIsPresent(ccdCaseRefs.get(0), "LISTED"))
+            doReturn(TestingUtil.getHearingsResponseWhenDataIsPresent(ccdCaseRefs.getFirst(),
+                                                                      HearingStatus.LISTED.name()))
                 .when(hearingManagementService)
                 .getHearings(any(), any());
             HearingManagementController controller = new HearingManagementController(
@@ -374,8 +374,8 @@ class HearingManagementControllerTest {
             );
             List<GetHearingsResponse> hearingsResponseList = controller.getHearingsForListOfCases(ccdCaseRefs, null);
             verify(hearingManagementService, times(1)).getHearings(any(), any());
-            assertEquals(hearingsResponseList.get(0).getCaseRef(), ccdCaseRefs.get(0));
-            assertTrue(hearingsResponseList.get(0).getCaseHearings().get(0).getHearingIsLinkedFlag());
+            assertThat(hearingsResponseList.getFirst().getCaseRef()).isEqualTo(ccdCaseRefs.getFirst());
+            assertThat(hearingsResponseList.getFirst().getCaseHearings().getFirst().getHearingIsLinkedFlag()).isTrue();
         }
 
         @Test
@@ -393,8 +393,8 @@ class HearingManagementControllerTest {
             );
             List<GetHearingsResponse> hearingsResponseList = controller.getHearingsForListOfCases(ccdCaseRefs, null);
             verify(hearingManagementService, times(2)).getHearings(any(), any());
-            assertEquals(hearingsResponseList.get(0).getCaseRef(), ccdCaseRefs.get(1));
-            assertTrue(hearingsResponseList.get(0).getCaseHearings().get(0).getHearingIsLinkedFlag());
+            assertThat(hearingsResponseList.getFirst().getCaseRef()).isEqualTo(ccdCaseRefs.get(1));
+            assertThat(hearingsResponseList.getFirst().getCaseHearings().getFirst().getHearingIsLinkedFlag()).isTrue();
         }
     }
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/HMAN-888

### Change description ###

Get Hearing actuals should return a HTTP 200 with content. However, the apiResponse in the controller incorrectly returns a HTTP 204 no content. Fix.
**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
