### PR TITLE
Removed TF Import block as resource already imported

### DIFF
--- a/infrastructure/import.tf
+++ b/infrastructure/import.tf
@@ -1,4 +1,0 @@
-import {
-  to = module.postgresql_v15_replica[0].azurerm_postgresql_flexible_server_active_directory_administrator.pgsql_adadmin
-  id = "/subscriptions/1c4f0704-a29e-403d-b719-b90c34ef14c9/resourceGroups/hmc-cft-hearing-service-postgres-db-v15-data-aat/providers/Microsoft.DBforPostgreSQL/flexibleServers/hmc-cft-hearing-service-postgres-db-v15-replica-aat/administrators/e7ea2042-4ced-45dd-8ae3-e051c6551789"
-}


### PR DESCRIPTION
**Before creating a pull request make sure that:**

- [X] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DTSPO-28009

### Change description ###

Removed import.tf which contained only import block for pgsql_adadmin. Resource imported successfully previously in this PR: (https://github.com/hmcts/hmc-cft-hearing-service/pull/611) , I believe this import.tf/import block is now causing pipeline failure

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
