### PR TITLE
HMAN-1084: Validate JWT issuer

### DIFF
--- a/charts/hmc-cft-hearing-service/Chart.yaml
+++ b/charts/hmc-cft-hearing-service/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.0"
 description: A Helm chart for hmc-cft-hearing-service App
 name: hmc-cft-hearing-service
 home: https://github.com/hmcts/hmc-cft-hearing-service
-version: 1.6.25
+version: 1.6.26
 maintainers:
   - name: HMCTS CCD Dev Team
 dependencies:

--- a/charts/hmc-cft-hearing-service/values.preview.template.yaml
+++ b/charts/hmc-cft-hearing-service/values.preview.template.yaml
@@ -23,6 +23,7 @@ java:
     HMI_DESTINATION_SYSTEM: SNL
     FH_BASE_URL: http://ccd-test-stubs-service-aat.service.core-compute-aat.internal
     FH_GET_TOKEN_URL: /oauth2/token
+    OIDC_ISSUER: https://forgerock-am.service.core-compute-idam-aat2.internal:8443/openam/oauth2/realms/root/realms/hmcts
   postgresql:
     enabled: true
   secrets:

--- a/charts/hmc-cft-hearing-service/values.yaml
+++ b/charts/hmc-cft-hearing-service/values.yaml
@@ -48,7 +48,9 @@ java:
     HMC_SERVICE_BUS_QUEUE: hmc-from-hmi-{{ .Values.global.environment }}
     HMC_OUTBOUND_SERVICE_BUS_QUEUE: hmc-to-hmi-{{ .Values.global.environment }}
     IDAM_OIDC_URL: https://idam-web-public.{{ .Values.global.environment }}.platform.hmcts.net
-    OIDC_ISSUER: https://forgerock-am.service.core-compute-idam-{{ .Values.global.environment }}.internal:8443/openam/oauth2/hmcts
+    OIDC_ISSUER_WEB_PUBLIC: https://idam-web-public.{{ .Values.global.environment }}.platform.hmcts.net/o
+    OIDC_ISSUER_HMCTS_ACCESS: https://hmcts-access.{{ .Values.global.environment }}.platform.hmcts.net/o
+    OIDC_ISSUER: https://forgerock-am.service.core-compute-idam-{{ .Values.global.environment }}.internal:8443/openam/oauth2/realms/root/realms/hmcts
     IDAM_API_URL: https://idam-api.{{ .Values.global.environment }}.platform.hmcts.net
     S2S_URL: http://rpe-service-auth-provider-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal
     HTTP_CLIENT_CONNECTION_TIMEOUT: '10000'

--- a/src/integrationTest/java/uk/gov/hmcts/reform/hmc/config/JwtDecoderIT.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/hmc/config/JwtDecoderIT.java
@@ -1,0 +1,171 @@
+package uk.gov.hmcts.reform.hmc.config;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.nimbusds.jose.JOSEException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.contract.wiremock.AutoConfigureWireMock;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.RequestBuilder;
+
+import java.time.Instant;
+import java.util.Map;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static org.hamcrest.Matchers.containsString;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static uk.gov.hmcts.reform.hmc.utils.KeyGenerator.getRsaJwk;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@AutoConfigureWireMock(port = 0, stubs = "classpath:/wiremock-stubs")
+@ActiveProfiles("itest")
+class JwtDecoderIT {
+    // Note: Class cannot inherit from BaseTest as security filters need to be enabled for tests
+
+    private static final String URL_HEARING = "/hearing";
+    private static final String REQUEST_HEADER_SERVICE_AUTHORISATION = "ServiceAuthorization";
+    private static final String REQUEST_HEADER_AUTHORISATION = "Authorization";
+    private static final String RESPONSE_HEADER_WWW_AUTHENTICATE = "WWW-Authenticate";
+
+    private static final String CCD_GET_CASE_DETAILS_RESPONSE = """
+        {
+            "jurisdiction": "Jurisdiction1",
+            "case_type": "CaseType1"
+        }""";
+
+    private static final String INVALID_ISSUER = "http://invalidIssuer";
+
+    private static final String DELETE_HEARING_DATA_SCRIPT = "classpath:sql/delete-hearing-tables.sql";
+    private static final String GET_HEARINGS_DATA_SCRIPT = "classpath:sql/get-caseHearings_request.sql";
+
+    private final MockMvc mockMvc;
+
+    private static final String VALID_ISSUER_WEB_PUBLIC = "http://localhost:5000/o";
+    private static final String VALID_ISSUER_FORGEROCK = "http://fr-am:8080/openam/oauth2/hmcts";
+
+    @Autowired
+    public JwtDecoderIT(MockMvc mockMvc) {
+        this.mockMvc = mockMvc;
+    }
+
+    @BeforeEach
+    void setUp() {
+        stubFor(WireMock.get("/s2s/details")
+                    .withHeader(REQUEST_HEADER_AUTHORISATION, WireMock.equalTo("Bearer 1234"))
+                    .willReturn(WireMock.ok("xui_webapp")));
+    }
+
+    @Test
+    void jwtTimestampValidator_shouldFailIfExpiresAtInPast() throws Exception {
+        Instant currentInstant = Instant.now();
+        Instant issuedAt = currentInstant.minusSeconds(3600);
+        Instant expiresAt = currentInstant.minusSeconds(1800);
+        Instant notBefore = currentInstant.minusSeconds(3600);
+
+        String userToken = createUserToken(issuedAt, expiresAt, notBefore);
+
+        RequestBuilder getHearingRequest = createGetHearingRequest(userToken);
+        mockMvc.perform(getHearingRequest)
+            .andExpect(status().isUnauthorized())
+            .andExpect(header().exists(RESPONSE_HEADER_WWW_AUTHENTICATE))
+            .andExpect(header().string(RESPONSE_HEADER_WWW_AUTHENTICATE, containsString("Jwt expired at")));
+    }
+
+    @Test
+    void jwtTimestampValidator_shouldFailIfNotBeforeInFuture() throws Exception {
+        Instant currentInstant = Instant.now();
+        Instant issuedAt = currentInstant.minusSeconds(3600);
+        Instant expiresAt = currentInstant.plusSeconds(3600);
+        Instant notBefore = currentInstant.plusSeconds(1800);
+
+        String userToken = createUserToken(issuedAt, expiresAt, notBefore);
+
+        RequestBuilder getHearingRequest = createGetHearingRequest(userToken);
+        mockMvc.perform(getHearingRequest)
+            .andExpect(status().isUnauthorized())
+            .andExpect(header().exists(RESPONSE_HEADER_WWW_AUTHENTICATE))
+            .andExpect(header().string(RESPONSE_HEADER_WWW_AUTHENTICATE, containsString("Jwt used before")));
+    }
+
+    @Test
+    void multiIssuerValidator_shouldFailIfIssuerInvalid() throws Exception {
+        String userToken = createUserToken(INVALID_ISSUER);
+
+        RequestBuilder getHearingRequest = createGetHearingRequest(userToken);
+        mockMvc.perform(getHearingRequest)
+            .andExpect(status().isUnauthorized())
+            .andExpect(header().exists(RESPONSE_HEADER_WWW_AUTHENTICATE))
+            .andExpect(header().string(RESPONSE_HEADER_WWW_AUTHENTICATE,
+                                       containsString("The issuer is missing or invalid")));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {VALID_ISSUER_FORGEROCK, VALID_ISSUER_WEB_PUBLIC})
+    @Sql(scripts = {DELETE_HEARING_DATA_SCRIPT, GET_HEARINGS_DATA_SCRIPT})
+    void multiIssuerValidator_shouldSucceedWithValidIssuer(String validIssuer) throws Exception {
+        stubCcdGetCaseDetails();
+
+        String userToken = createUserToken(validIssuer);
+
+        RequestBuilder getHearingRequest = createGetHearingRequest(userToken);
+        mockMvc.perform(getHearingRequest).andExpect(status().isOk());
+    }
+
+    private void stubCcdGetCaseDetails() {
+        stubFor(WireMock.get(WireMock.urlMatching("/cases/.*"))
+                    .willReturn(WireMock.okJson(CCD_GET_CASE_DETAILS_RESPONSE)));
+    }
+
+    private String createUserToken(String validIssuer) throws JOSEException {
+        Instant currentInstant = Instant.now();
+        Instant issuedAt = currentInstant.minusSeconds(3600);
+        Instant expiresAt = currentInstant.plusSeconds(3600);
+        Instant notBefore = currentInstant.minusSeconds(3600);
+
+        return createUserToken(validIssuer, issuedAt, expiresAt, notBefore);
+    }
+
+    private String createUserToken(Instant issuedAt, Instant expiresAt, Instant notBefore) throws JOSEException {
+        return createUserToken(VALID_ISSUER_FORGEROCK, issuedAt, expiresAt, notBefore);
+    }
+
+    private String createUserToken(String issuer, Instant issuedAt, Instant expiresAt, Instant notBefore)
+        throws JOSEException {
+
+        // Have to use keys created by KeyGenerator test utility class because WireMock
+        // is configured to return those details when JWKS are requested.
+        String userToken =
+            JWT.create()
+                .withHeader(Map.of("typ", "JWT",
+                                   "alg", "RS256",
+                                   "kid", "23456789"))
+                .withSubject("hmc_cft_hearing_service")
+                .withIssuer(issuer)
+                .withIssuedAt(issuedAt)
+                .withExpiresAt(expiresAt)
+                .withNotBefore(notBefore)
+                .sign(Algorithm.RSA256(getRsaJwk().toRSAPublicKey(), getRsaJwk().toRSAPrivateKey()));
+
+        return "Bearer " + userToken;
+    }
+
+    private RequestBuilder createGetHearingRequest(String userToken) {
+        return get(URL_HEARING + "/2000000000")
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .header(REQUEST_HEADER_SERVICE_AUTHORISATION, "1234")
+            .header(REQUEST_HEADER_AUTHORISATION, userToken);
+    }
+}

--- a/src/integrationTest/java/uk/gov/hmcts/reform/hmc/config/JwtDecoderIT.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/hmc/config/JwtDecoderIT.java
@@ -56,6 +56,9 @@ class JwtDecoderIT {
     private static final String VALID_ISSUER_WEB_PUBLIC = "http://localhost:5000/o";
     private static final String VALID_ISSUER_FORGEROCK = "http://fr-am:8080/openam/oauth2/hmcts";
 
+    private static final int ONE_HOUR_IN_SECONDS = 3600;
+    private static final int HALF_AN_HOUR_IN_SECONDS = 1800;
+
     @Autowired
     public JwtDecoderIT(MockMvc mockMvc) {
         this.mockMvc = mockMvc;
@@ -71,9 +74,9 @@ class JwtDecoderIT {
     @Test
     void jwtTimestampValidator_shouldFailIfExpiresAtInPast() throws Exception {
         Instant currentInstant = Instant.now();
-        Instant issuedAt = currentInstant.minusSeconds(3600);
-        Instant expiresAt = currentInstant.minusSeconds(1800);
-        Instant notBefore = currentInstant.minusSeconds(3600);
+        Instant issuedAt = currentInstant.minusSeconds(ONE_HOUR_IN_SECONDS);
+        Instant expiresAt = currentInstant.minusSeconds(HALF_AN_HOUR_IN_SECONDS);
+        Instant notBefore = currentInstant.minusSeconds(ONE_HOUR_IN_SECONDS);
 
         String userToken = createUserToken(issuedAt, expiresAt, notBefore);
 
@@ -87,9 +90,9 @@ class JwtDecoderIT {
     @Test
     void jwtTimestampValidator_shouldFailIfNotBeforeInFuture() throws Exception {
         Instant currentInstant = Instant.now();
-        Instant issuedAt = currentInstant.minusSeconds(3600);
-        Instant expiresAt = currentInstant.plusSeconds(3600);
-        Instant notBefore = currentInstant.plusSeconds(1800);
+        Instant issuedAt = currentInstant.minusSeconds(ONE_HOUR_IN_SECONDS);
+        Instant expiresAt = currentInstant.plusSeconds(ONE_HOUR_IN_SECONDS);
+        Instant notBefore = currentInstant.plusSeconds(HALF_AN_HOUR_IN_SECONDS);
 
         String userToken = createUserToken(issuedAt, expiresAt, notBefore);
 
@@ -131,9 +134,9 @@ class JwtDecoderIT {
 
     private String createUserToken(String validIssuer) throws JOSEException {
         Instant currentInstant = Instant.now();
-        Instant issuedAt = currentInstant.minusSeconds(3600);
-        Instant expiresAt = currentInstant.plusSeconds(3600);
-        Instant notBefore = currentInstant.minusSeconds(3600);
+        Instant issuedAt = currentInstant.minusSeconds(ONE_HOUR_IN_SECONDS);
+        Instant expiresAt = currentInstant.plusSeconds(ONE_HOUR_IN_SECONDS);
+        Instant notBefore = currentInstant.minusSeconds(ONE_HOUR_IN_SECONDS);
 
         return createUserToken(validIssuer, issuedAt, expiresAt, notBefore);
     }

--- a/src/main/java/uk/gov/hmcts/reform/hmc/config/IdamSecurityConfig.java
+++ b/src/main/java/uk/gov/hmcts/reform/hmc/config/IdamSecurityConfig.java
@@ -1,0 +1,17 @@
+package uk.gov.hmcts.reform.hmc.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+
+@Configuration
+@Getter
+@Setter
+@ConfigurationProperties("idam.security")
+public class IdamSecurityConfig {
+
+    private List<String> allowedIssuers;
+}

--- a/src/main/java/uk/gov/hmcts/reform/hmc/config/SecurityConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/hmc/config/SecurityConfiguration.java
@@ -19,6 +19,7 @@ import org.springframework.security.oauth2.server.resource.authentication.JwtAut
 import org.springframework.security.oauth2.server.resource.web.authentication.BearerTokenAuthenticationFilter;
 import org.springframework.security.web.SecurityFilterChain;
 import uk.gov.hmcts.reform.authorisation.filters.ServiceAuthFilter;
+import uk.gov.hmcts.reform.hmc.config.validator.MultiIssuerValidator;
 import uk.gov.hmcts.reform.hmc.security.JwtGrantedAuthoritiesConverter;
 
 import static org.springframework.security.config.http.SessionCreationPolicy.STATELESS;
@@ -27,11 +28,9 @@ import static org.springframework.security.config.http.SessionCreationPolicy.STA
 @EnableWebSecurity
 public class SecurityConfiguration {
 
-    @Value("${spring.security.oauth2.client.provider.oidc.issuer-uri}")
-    private String issuerUri;
+    private final String issuerUri;
 
-    @Value("${oidc.issuer}")
-    private String issuerOverride;
+    private final IdamSecurityConfig idamSecurityConfig;
 
     private final ServiceAuthFilter serviceAuthFilter;
     private final JwtAuthenticationConverter jwtAuthenticationConverter;
@@ -51,9 +50,12 @@ public class SecurityConfiguration {
     };
 
     @Autowired
-    public SecurityConfiguration(final ServiceAuthFilter serviceAuthFilter,
+    public SecurityConfiguration(@Value("${spring.security.oauth2.client.provider.oidc.issuer-uri}") String issuerUri,
+                                 IdamSecurityConfig idamSecurityConfig,
+                                 final ServiceAuthFilter serviceAuthFilter,
                                  final JwtGrantedAuthoritiesConverter jwtGrantedAuthoritiesConverter) {
-        super();
+        this.issuerUri = issuerUri;
+        this.idamSecurityConfig = idamSecurityConfig;
         this.serviceAuthFilter = serviceAuthFilter;
         jwtAuthenticationConverter = new JwtAuthenticationConverter();
         jwtAuthenticationConverter.setJwtGrantedAuthoritiesConverter(jwtGrantedAuthoritiesConverter);
@@ -62,7 +64,7 @@ public class SecurityConfiguration {
     @Bean
     public WebSecurityCustomizer webSecurityCustomizer() {
         return web -> web.ignoring().requestMatchers(AUTH_ALLOWED_LIST);
-    }    
+    }
 
     @Bean
     protected SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -78,13 +80,15 @@ public class SecurityConfiguration {
             .build();
     }
 
-
     @Bean
     JwtDecoder jwtDecoder() {
-        NimbusJwtDecoder jwtDecoder = (NimbusJwtDecoder)  JwtDecoders.fromOidcIssuerLocation(issuerUri);
         OAuth2TokenValidator<Jwt> withTimestamp = new JwtTimestampValidator();
-        OAuth2TokenValidator<Jwt> validator = new DelegatingOAuth2TokenValidator<>(withTimestamp);
+        OAuth2TokenValidator<Jwt> withMultiIssuer = new MultiIssuerValidator(idamSecurityConfig.getAllowedIssuers());
+        OAuth2TokenValidator<Jwt> validator = new DelegatingOAuth2TokenValidator<>(withTimestamp, withMultiIssuer);
+
+        NimbusJwtDecoder jwtDecoder = JwtDecoders.fromOidcIssuerLocation(issuerUri);
         jwtDecoder.setJwtValidator(validator);
+
         return jwtDecoder;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/hmc/config/validator/MultiIssuerValidator.java
+++ b/src/main/java/uk/gov/hmcts/reform/hmc/config/validator/MultiIssuerValidator.java
@@ -22,7 +22,7 @@ public class MultiIssuerValidator implements OAuth2TokenValidator<Jwt> {
     public MultiIssuerValidator(List<String> validIssuers) {
         Assert.notEmpty(validIssuers, "Valid issuers list should not be null or empty");
         Assert.noNullElements(validIssuers, "Valid issuers list should not contain any null elements");
-        log.debug("Valid issuers list: {}", validIssuers);
+        log.info("Valid issuers list: {}", validIssuers);
         this.validIssuers = validIssuers;
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/hmc/config/validator/MultiIssuerValidator.java
+++ b/src/main/java/uk/gov/hmcts/reform/hmc/config/validator/MultiIssuerValidator.java
@@ -1,0 +1,41 @@
+package uk.gov.hmcts.reform.hmc.config.validator;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.oauth2.core.OAuth2Error;
+import org.springframework.security.oauth2.core.OAuth2ErrorCodes;
+import org.springframework.security.oauth2.core.OAuth2TokenValidator;
+import org.springframework.security.oauth2.core.OAuth2TokenValidatorResult;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtClaimNames;
+import org.springframework.util.Assert;
+
+import java.util.List;
+
+@Slf4j
+public class MultiIssuerValidator implements OAuth2TokenValidator<Jwt> {
+
+    private final List<String> validIssuers;
+
+    private final OAuth2Error errorIssuerInvalid =
+        new OAuth2Error(OAuth2ErrorCodes.INVALID_TOKEN, "The issuer is missing or invalid", null);
+
+    public MultiIssuerValidator(List<String> validIssuers) {
+        Assert.notEmpty(validIssuers, "Valid issuers list should not be null or empty");
+        Assert.noNullElements(validIssuers, "Valid issuers list should not contain any null elements");
+        log.debug("Valid issuers list: {}", validIssuers);
+        this.validIssuers = validIssuers;
+    }
+
+    @Override
+    public OAuth2TokenValidatorResult validate(Jwt jwt) {
+        String issuer = jwt.getClaimAsString(JwtClaimNames.ISS) == null ? "" : jwt.getClaimAsString(JwtClaimNames.ISS);
+
+        if (!issuer.isEmpty() && validIssuers.contains(issuer)) {
+            log.debug("Valid issuer: [{}]", issuer);
+            return OAuth2TokenValidatorResult.success();
+        } else {
+            log.error("Invalid issuer: [{}]", issuer);
+            return OAuth2TokenValidatorResult.failure(errorIssuerInvalid);
+        }
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -137,9 +137,11 @@ idam:
     # same for all environments - not used in hmc but configured as idam mandates for token generation
     redirect_uri: https://cft-hearing-service/oauth2redirect
     secret: ${CFT_HEARING_SERVICE_IDAM_CLIENT_SECRET:AAAAAAAAAAAAAAAA}
-
-oidc:
-  issuer: ${OIDC_ISSUER:http://fr-am:8080/openam/oauth2/hmcts}
+  security:
+    allowed-issuers:
+      - ${OIDC_ISSUER_WEB_PUBLIC:http://localhost:5000/o}
+      - ${OIDC_ISSUER_HMCTS_ACCESS:http://localhost:5000/o}
+      - ${OIDC_ISSUER:http://fr-am:8080/openam/oauth2/hmcts}
 
 http:
   client:

--- a/src/test/java/uk/gov/hmcts/reform/hmc/config/validator/MultiIssuerValidatorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/hmc/config/validator/MultiIssuerValidatorTest.java
@@ -1,0 +1,182 @@
+package uk.gov.hmcts.reform.hmc.config.validator;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.security.oauth2.core.OAuth2Error;
+import org.springframework.security.oauth2.core.OAuth2TokenValidatorResult;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+class MultiIssuerValidatorTest {
+
+    private static final String ISSUER_VALID = "http://validIssuer";
+    private static final String ISSUER_VALID_OTHER = "http://otherValidIssuer";
+    private static final String ISSUER_EMPTY = "";
+    private static final String ISSUER_INVALID = "http://invalidIssuer";
+
+    private static final String AUTH_ERROR_INVALID_TOKEN = "invalid_token";
+
+    private static final String ZONE_EUROPE_LONDON = "Europe/London";
+    private static final String TOKEN_VALUE = "testTokenValue";
+
+    @Test
+    void initialisationShouldFailWithNullList() {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                                                          () -> new MultiIssuerValidator(null),
+                                                          "Exception should be thrown if list is null");
+        assertIllegalArgumentException(exception, "Valid issuers list should not be null or empty");
+    }
+
+    @Test
+    void initialisationShouldFailWithEmptyList() {
+        List<String> emptyList = Collections.emptyList();
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                                                          () -> new MultiIssuerValidator(emptyList),
+                                                          "Exception should be thrown is list is empty");
+        assertIllegalArgumentException(exception, "Valid issuers list should not be null or empty");
+    }
+
+    @ParameterizedTest
+    @MethodSource("listsWithNullIssuer")
+    void initialisationShouldFailWithNullIssuer(List<String> issuers) {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                                                          () -> new MultiIssuerValidator(issuers),
+                                                          "Exception should be thrown if list contains a null issuer");
+        assertIllegalArgumentException(exception, "Valid issuers list should not contain any null elements");
+    }
+
+    @Test
+    void initialisationShouldSucceed() {
+        List<String> listWithIssuer = List.of(ISSUER_VALID);
+        assertDoesNotThrow(() -> new MultiIssuerValidator(listWithIssuer),
+                           "Exception should not be thrown for non-null, non-empty list of non-null issuers");
+    }
+
+    @Test
+    void validateShouldFailForNoIssuer() {
+        MultiIssuerValidator validator = new MultiIssuerValidator(List.of(ISSUER_VALID));
+
+        Jwt jwtWithoutIssuer = createJwtWithoutIssuer();
+        OAuth2TokenValidatorResult result = validator.validate(jwtWithoutIssuer);
+
+        assertValidateFailure(result);
+    }
+
+    @Test
+    void validateShouldFailForEmptyIssuer() {
+        MultiIssuerValidator validator = new MultiIssuerValidator(List.of(ISSUER_VALID));
+
+        Jwt jwtWithEmptyIssuer = createJwt(ISSUER_EMPTY);
+        OAuth2TokenValidatorResult result = validator.validate(jwtWithEmptyIssuer);
+
+        assertValidateFailure(result);
+    }
+
+    @Test
+    void validateShouldFailForInvalidIssuer() {
+        MultiIssuerValidator validator = new MultiIssuerValidator(List.of(ISSUER_VALID));
+
+        Jwt jwtIssuerInvalid = createJwt(ISSUER_INVALID);
+        OAuth2TokenValidatorResult result = validator.validate(jwtIssuerInvalid);
+
+        assertValidateFailure(result);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {ISSUER_VALID_OTHER, ISSUER_VALID})
+    void validateShouldSucceed(String issuer) {
+        MultiIssuerValidator validator = new MultiIssuerValidator(List.of(ISSUER_VALID, ISSUER_VALID_OTHER));
+
+        Jwt jwtValid = createJwt(issuer);
+        OAuth2TokenValidatorResult result = validator.validate(jwtValid);
+
+        assertValidateSuccess(result);
+    }
+
+    private static Stream<Arguments> listsWithNullIssuer() {
+        List<String> onlyNullIssuer = new ArrayList<>();
+        onlyNullIssuer.add(null);
+
+        List<String> nonNullAndNullIssuer = new ArrayList<>();
+        nonNullAndNullIssuer.add(ISSUER_VALID);
+        nonNullAndNullIssuer.add(null);
+
+        return Stream.of(
+            arguments(onlyNullIssuer),
+            arguments(nonNullAndNullIssuer)
+        );
+    }
+
+    private void assertIllegalArgumentException(IllegalArgumentException exception, String expectedMessage) {
+        assertEquals(expectedMessage, exception.getMessage(), "Exception has unexpected message");
+    }
+
+    private void assertValidateFailure(OAuth2TokenValidatorResult result) {
+        assertTrue(result.hasErrors(), "Validator result should contain errors");
+
+        Collection<OAuth2Error> errors = result.getErrors();
+        assertEquals(1, errors.size(), "Validator result has unexpected number of errors");
+
+        Optional<OAuth2Error> errorOptional = errors.stream().findFirst();
+        assertTrue(errorOptional.isPresent(), "Validator result error should be present");
+
+        OAuth2Error error = errorOptional.get();
+        assertEquals(AUTH_ERROR_INVALID_TOKEN,
+                     error.getErrorCode(),
+                     "Validator result error has unexpected error code");
+        assertEquals("The issuer is missing or invalid",
+                     error.getDescription(),
+                     "Validator result error has unexpected description");
+    }
+
+    private void assertValidateSuccess(OAuth2TokenValidatorResult result) {
+        assertFalse(result.hasErrors(), "Validator result should not contain errors");
+    }
+
+    private Jwt createJwtWithoutIssuer() {
+        Map<String, Object> claims = new HashMap<>();
+        claims.put("token_type", "Bearer");
+
+        return createJwt(claims);
+    }
+
+    private Jwt createJwt(String issuer) {
+        Map<String, Object> claims = new HashMap<>();
+        claims.put("iss", issuer);
+        claims.put("token_type", "Bearer");
+
+        return createJwt(claims);
+    }
+
+    private Jwt createJwt(Map<String, Object> claims) {
+        LocalDateTime currentDateTime = LocalDateTime.now();
+        Instant issuedAt = currentDateTime.atZone(ZoneId.of(ZONE_EUROPE_LONDON)).toInstant();
+        Instant expiresAt = currentDateTime.plusHours(8L).atZone(ZoneId.of(ZONE_EUROPE_LONDON)).toInstant();
+
+        Map<String, Object> headers = new HashMap<>();
+        headers.put("typ", "JWT");
+
+        return new Jwt(TOKEN_VALUE, issuedAt, expiresAt, headers, claims);
+    }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###
[HMAN-1084](https://tools.hmcts.net/jira/browse/HMAN-1084)


### Change description ###
Added new MultiIssuerValidator class to validate issuer of JWT against a list of valid issuers.

Replaced oidc.issuer property in application.yaml with idam.security.allowed-issuers property.  This specifies a list of allowed issuers.

Added IdamSecurityConfig class.  This maps to idam.security in application.yaml and holds the list of allowed issuers.

Updated creation of JwtDecoder bean in SecurityConfiguration class to include MultiIssuerValidator.

Updated constructor for SecurityConfiguration class to include issuerUri property and IdamSecurityConfig. Adding the property to the constructor instead of annotation the corresponding field will permit easier testing of class. Also removed redundant call to super().

Added two new issuer environment variables in values.yaml to supplement the existing OIDC_ISSUER one. These are used to specify the valid issuers in each environment. Added forgerock issuer environment variable to values.preview.template.yaml as AAT name is slightly different.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
