### PR TITLE
HMAN-1131: Handle null not required field and update actual hearing day validation logic

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/hmc/controllers/HearingActualsManagementControllerIT.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/hmc/controllers/HearingActualsManagementControllerIT.java
@@ -12,6 +12,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
@@ -23,6 +26,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 import uk.gov.hmcts.reform.hmc.BaseTest;
 import uk.gov.hmcts.reform.hmc.TestFixtures;
+import uk.gov.hmcts.reform.hmc.data.ActualHearingDayEntity;
 import uk.gov.hmcts.reform.hmc.data.ActualHearingEntity;
 import uk.gov.hmcts.reform.hmc.data.RoleAssignmentResponse;
 import uk.gov.hmcts.reform.hmc.interceptors.OverrideHostPolicy;
@@ -33,12 +37,20 @@ import wiremock.com.jayway.jsonpath.DocumentContext;
 import wiremock.com.jayway.jsonpath.JsonPath;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneOffset;
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Stream;
 
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.Matchers.hasSize;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Named.named;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -1068,8 +1080,141 @@ class HearingActualsManagementControllerIT extends BaseTest {
         }
     }
 
-    private final String serviceJwtXuiWeb = generateDummyS2SToken("ccd_definition");
+    @Nested
+    @DisplayName("PutHearingActuals - hearing day not required field has null value")
+    class PutHearingActualsNotRequiredNull {
 
+        @Test
+        @Sql(scripts = {DELETE_HEARING_DATA_SCRIPT, INSERT_HEARING_ACTUALS})
+        void shouldReturn400WhenHearingDayInFutureNotRequiredNullNotEmpty() throws Exception {
+            LocalDate hearingDateFuture = LocalDate.now().plusDays(1L);
+            LocalDateTime hearingStartTimeFuture = LocalDateTime.of(hearingDateFuture, LocalTime.of(12, 0, 0));
+            LocalDateTime hearingEndTimeFuture = hearingStartTimeFuture.plusHours(1L);
+
+            String json =
+                createHearingActualJsonHearingDay(hearingDateFuture, hearingStartTimeFuture, hearingEndTimeFuture);
+
+            mockMvc.perform(put(URL + "/2000001000")
+                                .header(SERVICE_AUTHORIZATION, serviceJwtXuiWeb)
+                                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                                .content(json))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errors", hasSize(1)))
+                .andExpect(jsonPath("$.errors", hasItem(HEARING_ACTUALS_INVALID_STATUS)));
+        }
+
+        @ParameterizedTest(name = "{index}: {0}")
+        @MethodSource("validHearingDays")
+        @Sql(scripts = {DELETE_HEARING_DATA_SCRIPT, INSERT_HEARING_ACTUALS})
+        void shouldReturn200WhenHearingDayNotRequiredNull(String json,
+                                                          LocalDate hearingDate,
+                                                          LocalDateTime hearingStartTime,
+                                                          LocalDateTime hearingEndTime) throws Exception {
+            mockMvc.perform(put(URL + "/2000001000")
+                                .header(SERVICE_AUTHORIZATION, serviceJwtXuiWeb)
+                                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                                .content(json))
+                .andExpect(status().isOk());
+
+            ActualHearingDayEntity day =
+                entityManager.createQuery("SELECT hd FROM ActualHearingDayEntity hd", ActualHearingDayEntity.class)
+                    .getSingleResult();
+
+            assertEquals(hearingDate, day.getHearingDate(), "Actual hearing day has unexpected hearing date");
+            if (hearingStartTime == null) {
+                assertNull(day.getStartDateTime(), "Actual hearing day start time should be null");
+            } else {
+                assertEquals(hearingStartTime, day.getStartDateTime(), "Actual hearing day has unexpected start time");
+            }
+            if (hearingEndTime == null) {
+                assertNull(day.getEndDateTime(), "Actual hearing day end time should be null");
+            } else {
+                assertEquals(hearingEndTime, day.getEndDateTime(), "Actual hearing day has unexpected end time");
+            }
+            assertFalse(day.getNotRequired(), "Actual hearing day not required flag should be false");
+        }
+
+        private static Stream<Arguments> validHearingDays() {
+            LocalDate hearingDateToday = LocalDate.now();
+            LocalDateTime hearingStartTimeToday = LocalDateTime.of(hearingDateToday, LocalTime.of(12, 0, 0));
+            LocalDateTime hearingEndTimeToday = LocalDateTime.of(hearingDateToday, LocalTime.of(13, 0, 0));
+
+            LocalDate hearingDateFuture = hearingDateToday.plusDays(1L);
+
+            return Stream.of(
+                arguments(named("Hearing date in future, hearing day empty",
+                                createHearingActualJsonEmptyHearingDay(hearingDateFuture)
+                          ),
+                          hearingDateFuture,
+                          null,
+                          null),
+                arguments(named("Hearing date today, hearing day empty",
+                                createHearingActualJsonEmptyHearingDay(hearingDateToday)
+                          ),
+                          hearingDateToday,
+                          null,
+                          null),
+                arguments(named("Hearing date today, hearing day not empty",
+                                createHearingActualJsonHearingDay(hearingDateToday,
+                                                                  hearingStartTimeToday,
+                                                                  hearingEndTimeToday)
+                          ),
+                          hearingDateToday,
+                          hearingStartTimeToday,
+                          hearingEndTimeToday)
+            );
+        }
+
+        private static String createHearingActualJsonHearingDay(LocalDate hearingDate,
+                                                                LocalDateTime hearingStartTime,
+                                                                LocalDateTime hearingEndTime) {
+            return """
+                {
+                    "hearingOutcome": {
+                        "hearingType": "Witness Hearing",
+                        "hearingFinalFlag": true,
+                        "hearingResult": "COMPLETED",
+                        "hearingResultDate": "2026-05-26"
+                    },
+                    "actualHearingDays": [
+                        {
+                            "hearingDate": "%s",
+                            "hearingStartTime": "%s",
+                            "hearingEndTime": "%s",
+                            "notRequired": null,
+                            "pauseDateTimes": [],
+                            "actualDayParties": []
+                        }
+                    ]
+                }""".formatted(hearingDate,
+                               hearingStartTime.toInstant(ZoneOffset.UTC).toString(),
+                               hearingEndTime.toInstant(ZoneOffset.UTC).toString());
+        }
+
+        private static String createHearingActualJsonEmptyHearingDay(LocalDate hearingDate) {
+            return """
+                {
+                    "hearingOutcome": {
+                        "hearingType": "Witness Hearing",
+                        "hearingFinalFlag": true,
+                        "hearingResult": "COMPLETED",
+                        "hearingResultDate": "2026-05-26"
+                    },
+                    "actualHearingDays": [
+                        {
+                            "hearingDate": "%s",
+                            "hearingStartTime": null,
+                            "hearingEndTime": null,
+                            "notRequired": null,
+                            "pauseDateTimes": [],
+                            "actualDayParties": []
+                        }
+                    ]
+                }""".formatted(hearingDate);
+        }
+    }
+
+    private final String serviceJwtXuiWeb = generateDummyS2SToken("ccd_definition");
 
     private static RoleAssignmentResponse stubRoleAssignments() {
         RoleAssignmentResponse response = new RoleAssignmentResponse();

--- a/src/integrationTest/java/uk/gov/hmcts/reform/hmc/controllers/HearingActualsManagementControllerIT.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/hmc/controllers/HearingActualsManagementControllerIT.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
@@ -49,6 +50,7 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Named.named;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -1211,6 +1213,316 @@ class HearingActualsManagementControllerIT extends BaseTest {
                         }
                     ]
                 }""".formatted(hearingDate);
+        }
+    }
+
+    @Nested
+    @DisplayName("PutHearingActuals - hearing day not required field not present")
+    class PutHearingActualsNotRequiredNotPresent {
+
+        @Test
+        @Sql(scripts = {DELETE_HEARING_DATA_SCRIPT, INSERT_HEARING_ACTUALS})
+        void shouldReturn400WhenHearingDayInFutureNotRequiredNotPresentNotEmpty() throws Exception {
+            LocalDate hearingDateFuture = LocalDate.now().plusDays(1L);
+            LocalDateTime hearingStartTimeFuture = LocalDateTime.of(hearingDateFuture, LocalTime.of(12, 0, 0));
+            LocalDateTime hearingEndTimeFuture = hearingStartTimeFuture.plusHours(1L);
+
+            String json =
+                createHearingActualJsonHearingDay(hearingDateFuture, hearingStartTimeFuture, hearingEndTimeFuture);
+
+            mockMvc.perform(put(URL + "/2000001000")
+                                .header(SERVICE_AUTHORIZATION, serviceJwtXuiWeb)
+                                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                                .content(json))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errors", hasSize(1)))
+                .andExpect(jsonPath("$.errors", hasItem(HEARING_ACTUALS_INVALID_STATUS)));
+        }
+
+        @ParameterizedTest(name = "{index}: {0}")
+        @MethodSource("validHearingDays")
+        @Sql(scripts = {DELETE_HEARING_DATA_SCRIPT, INSERT_HEARING_ACTUALS})
+        void shouldReturn200WhenHearingDayNotRequiredNotPresent(String json,
+                                                                LocalDate hearingDate,
+                                                                LocalDateTime hearingStartTime,
+                                                                LocalDateTime hearingEndTime) throws Exception {
+            mockMvc.perform(put(URL + "/2000001000")
+                                .header(SERVICE_AUTHORIZATION, serviceJwtXuiWeb)
+                                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                                .content(json))
+                .andExpect(status().isOk());
+
+            ActualHearingDayEntity day =
+                entityManager.createQuery("SELECT hd FROM ActualHearingDayEntity hd", ActualHearingDayEntity.class)
+                    .getSingleResult();
+
+            assertEquals(hearingDate, day.getHearingDate(), "Actual hearing day has unexpected hearing date");
+            if (hearingStartTime == null) {
+                assertNull(day.getStartDateTime(), "Actual hearing day start time should be null");
+            } else {
+                assertEquals(hearingStartTime, day.getStartDateTime(), "Actual hearing day has unexpected start time");
+            }
+            if (hearingEndTime == null) {
+                assertNull(day.getEndDateTime(), "Actual hearing day end time should be null");
+            } else {
+                assertEquals(hearingEndTime, day.getEndDateTime(), "Actual hearing day has unexpected end time");
+            }
+            assertFalse(day.getNotRequired(), "Actual hearing day not required flag should be false");
+        }
+
+        private static Stream<Arguments> validHearingDays() {
+            LocalDate hearingDateToday = LocalDate.now();
+            LocalDateTime hearingStartTimeToday = LocalDateTime.of(hearingDateToday, LocalTime.of(12, 0, 0));
+            LocalDateTime hearingEndTimeToday = LocalDateTime.of(hearingDateToday, LocalTime.of(13, 0, 0));
+
+            LocalDate hearingDateFuture = hearingDateToday.plusDays(1L);
+
+            return Stream.of(
+                arguments(named("Hearing date in future, hearing day empty",
+                                createHearingActualJsonEmptyHearingDay(hearingDateFuture)
+                          ),
+                          hearingDateFuture,
+                          null,
+                          null),
+                arguments(named("Hearing date today, hearing day empty",
+                                createHearingActualJsonEmptyHearingDay(hearingDateToday)
+                          ),
+                          hearingDateToday,
+                          null,
+                          null),
+                arguments(named("Hearing date today, hearing day not empty",
+                                createHearingActualJsonHearingDay(hearingDateToday,
+                                                                  hearingStartTimeToday,
+                                                                  hearingEndTimeToday)
+                          ),
+                          hearingDateToday,
+                          hearingStartTimeToday,
+                          hearingEndTimeToday)
+            );
+        }
+
+        private static String createHearingActualJsonHearingDay(LocalDate hearingDate,
+                                                                LocalDateTime hearingStartTime,
+                                                                LocalDateTime hearingEndTime) {
+            return """
+                {
+                    "hearingOutcome": {
+                        "hearingType": "Witness Hearing",
+                        "hearingFinalFlag": true,
+                        "hearingResult": "COMPLETED",
+                        "hearingResultDate": "2026-05-26"
+                    },
+                    "actualHearingDays": [
+                        {
+                            "hearingDate": "%s",
+                            "hearingStartTime": "%s",
+                            "hearingEndTime": "%s",
+                            "pauseDateTimes": [],
+                            "actualDayParties": []
+                        }
+                    ]
+                }""".formatted(hearingDate,
+                               hearingStartTime.toInstant(ZoneOffset.UTC).toString(),
+                               hearingEndTime.toInstant(ZoneOffset.UTC).toString());
+        }
+
+        private static String createHearingActualJsonEmptyHearingDay(LocalDate hearingDate) {
+            return """
+                {
+                    "hearingOutcome": {
+                        "hearingType": "Witness Hearing",
+                        "hearingFinalFlag": true,
+                        "hearingResult": "COMPLETED",
+                        "hearingResultDate": "2026-05-26"
+                    },
+                    "actualHearingDays": [
+                        {
+                            "hearingDate": "%s",
+                            "hearingStartTime": null,
+                            "hearingEndTime": null,
+                            "pauseDateTimes": [],
+                            "actualDayParties": []
+                        }
+                    ]
+                }""".formatted(hearingDate);
+        }
+    }
+
+    @Nested
+    @DisplayName("PutHearingActuals - hearing day not required field has a value set")
+    class PutHearingActualsNotRequiredSet {
+
+        @ParameterizedTest
+        @ValueSource(booleans = {false, true})
+        @Sql(scripts = {DELETE_HEARING_DATA_SCRIPT, INSERT_HEARING_ACTUALS})
+        void shouldReturn400(boolean notRequired) throws Exception {
+            LocalDate hearingDateFuture = LocalDate.now().plusDays(1L);
+            LocalDateTime hearingStartTimeFuture = LocalDateTime.of(hearingDateFuture, LocalTime.of(12, 0, 0));
+            LocalDateTime hearingEndTimeFuture = hearingStartTimeFuture.plusHours(1L);
+
+            String json = createHearingActualJsonHearingDay(hearingDateFuture,
+                                                            hearingStartTimeFuture,
+                                                            hearingEndTimeFuture,
+                                                            notRequired);
+
+            mockMvc.perform(put(URL + "/2000001000")
+                                .header(SERVICE_AUTHORIZATION, serviceJwtXuiWeb)
+                                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                                .content(json))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errors", hasSize(1)))
+                .andExpect(jsonPath("$.errors", hasItem(HEARING_ACTUALS_INVALID_STATUS)));
+        }
+
+        @ParameterizedTest(name = "{index}: {0}")
+        @MethodSource("hearingDaysValid")
+        @Sql(scripts = {DELETE_HEARING_DATA_SCRIPT, INSERT_HEARING_ACTUALS})
+        void shouldReturn200(String json,
+                             LocalDate hearingDate,
+                             LocalDateTime hearingStartTime,
+                             LocalDateTime hearingEndTime,
+                             boolean notRequired) throws Exception {
+
+            mockMvc.perform(put(URL + "/2000001000")
+                                .header(SERVICE_AUTHORIZATION, serviceJwtXuiWeb)
+                                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                                .content(json))
+                .andExpect(status().isOk());
+
+            ActualHearingDayEntity day =
+                entityManager.createQuery("SELECT hd FROM ActualHearingDayEntity hd", ActualHearingDayEntity.class)
+                    .getSingleResult();
+
+            assertEquals(hearingDate, day.getHearingDate(), "Actual hearing day has unexpected hearing date");
+            if (hearingStartTime == null) {
+                assertNull(day.getStartDateTime(), "Actual hearing day start time should be null");
+            } else {
+                assertEquals(hearingStartTime, day.getStartDateTime(), "Actual hearing day has unexpected start time");
+            }
+            if (hearingEndTime == null) {
+                assertNull(day.getEndDateTime(), "Actual hearing day end time should be null");
+            } else {
+                assertEquals(hearingEndTime, day.getEndDateTime(), "Actual hearing day has unexpected end time");
+            }
+            if (notRequired) {
+                assertTrue(day.getNotRequired(), "Actual hearing day not required flag should be true");
+            } else {
+                assertFalse(day.getNotRequired(), "Actual hearing day not required flag should be false");
+            }
+        }
+
+        private static Stream<Arguments> hearingDaysValid() {
+            LocalDate hearingDateFuture = LocalDate.now().plusDays(1L);
+
+            LocalDate hearingDateToday = LocalDate.now();
+            LocalDateTime hearingStartTimeToday = LocalDateTime.of(hearingDateToday, LocalTime.of(12, 0, 0));
+            LocalDateTime hearingEndTimeToday = hearingStartTimeToday.plusHours(1L);
+
+            return Stream.of(
+                arguments(named("Hearing date in future, hearing day empty, not required is false",
+                                createHearingActualJsonEmptyHearingDay(hearingDateFuture, false)
+                          ),
+                          hearingDateFuture,
+                          null,
+                          null,
+                          false
+                ),
+                arguments(named("Hearing date in future, hearing day empty, not required is true",
+                                createHearingActualJsonEmptyHearingDay(hearingDateFuture, true)
+                          ),
+                          hearingDateFuture,
+                          null,
+                          null,
+                          true
+                ),
+                arguments(named("Hearing date today, hearing day empty, not required is false",
+                                createHearingActualJsonEmptyHearingDay(hearingDateToday, false)
+                          ),
+                          hearingDateToday,
+                          null,
+                          null,
+                          false
+                ),
+                arguments(named("Hearing date today, hearing day not empty, not required is false",
+                                createHearingActualJsonHearingDay(hearingDateToday,
+                                                                  hearingStartTimeToday,
+                                                                  hearingEndTimeToday,
+                                                                  false)
+                          ),
+                          hearingDateToday,
+                          hearingStartTimeToday,
+                          hearingEndTimeToday,
+                          false
+                ),
+                arguments(named("Hearing date today, hearing day empty, not required is true",
+                                createHearingActualJsonEmptyHearingDay(hearingDateToday, true)),
+                          hearingDateToday,
+                          null,
+                          null,
+                          true
+                ),
+                arguments(named("Hearing date today, hearing day not empty, not required is true",
+                                createHearingActualJsonHearingDay(hearingDateToday,
+                                                                  hearingStartTimeToday,
+                                                                  hearingEndTimeToday,
+                                                                  true)
+                          ),
+                          hearingDateToday,
+                          hearingStartTimeToday,
+                          hearingEndTimeToday,
+                          true
+                )
+            );
+        }
+
+        private static String createHearingActualJsonHearingDay(LocalDate hearingDate,
+                                                                LocalDateTime hearingStartTime,
+                                                                LocalDateTime hearingEndTime,
+                                                                boolean notRequired) {
+            return """
+                {
+                    "hearingOutcome": {
+                        "hearingType": "Witness Hearing",
+                        "hearingFinalFlag": true,
+                        "hearingResult": "COMPLETED",
+                        "hearingResultDate": "2026-05-26"
+                    },
+                    "actualHearingDays": [
+                        {
+                            "hearingDate": "%s",
+                            "hearingStartTime": "%s",
+                            "hearingEndTime": "%s",
+                            "notRequired": %s,
+                            "pauseDateTimes": [],
+                            "actualDayParties": []
+                        }
+                    ]
+                }""".formatted(hearingDate,
+                               hearingStartTime.toInstant(ZoneOffset.UTC).toString(),
+                               hearingEndTime.toInstant(ZoneOffset.UTC).toString(),
+                               notRequired);
+        }
+
+        private static String createHearingActualJsonEmptyHearingDay(LocalDate hearingDate, boolean notRequired) {
+            return """
+                {
+                    "hearingOutcome": {
+                        "hearingType": "Witness Hearing",
+                        "hearingFinalFlag": true,
+                        "hearingResult": "COMPLETED",
+                        "hearingResultDate": "2026-05-26"
+                    },
+                    "actualHearingDays": [
+                        {
+                            "hearingDate": "%s",
+                            "hearingStartTime": null,
+                            "hearingEndTime": null,
+                            "notRequired": %s,
+                            "pauseDateTimes": [],
+                            "actualDayParties": []
+                        }
+                    ]
+                }""".formatted(hearingDate, notRequired);
         }
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/hmc/model/ActualHearingDay.java
+++ b/src/main/java/uk/gov/hmcts/reform/hmc/model/ActualHearingDay.java
@@ -2,8 +2,10 @@ package uk.gov.hmcts.reform.hmc.model;
 
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.springframework.format.annotation.DateTimeFormat;
 import uk.gov.hmcts.reform.hmc.exceptions.ValidationError;
 
@@ -32,8 +34,13 @@ public class ActualHearingDay implements Serializable {
     @Valid
     private List<ActualHearingDayParties> actualDayParties;
 
-    // TODO: Remove the default after EXUI-1111 deployment (see HMAN-1120)
+    // TODO: Remove the default and custom setter and add NotNull annotation after EXUI-1111 deployment (see HMAN-1120)
+    @Setter(AccessLevel.NONE)
     private Boolean notRequired = false;
+
+    public void setNotRequired(Boolean notRequired) {
+        this.notRequired = notRequired == null ? false : notRequired;
+    }
 
     public boolean isEmpty() {
         return hearingStartTime == null
@@ -41,5 +48,4 @@ public class ActualHearingDay implements Serializable {
             && (pauseDateTimes == null || pauseDateTimes.isEmpty())
             && (actualDayParties == null || actualDayParties.isEmpty());
     }
-
 }

--- a/src/main/java/uk/gov/hmcts/reform/hmc/validator/HearingActualsValidator.java
+++ b/src/main/java/uk/gov/hmcts/reform/hmc/validator/HearingActualsValidator.java
@@ -92,12 +92,9 @@ public class HearingActualsValidator {
             }
             LocalDate hearingDate = hearingDay.getHearingDate();
             boolean isHearingDayEmpty = hearingDay.isEmpty();
-            Boolean notRequired = hearingDay.getNotRequired();
 
-            if (hearingDate.isAfter(today) || hearingDate.equals(today)) {
-                if (notRequired == null || !isHearingDayEmpty) {
-                    throw new BadRequestException(HEARING_ACTUALS_INVALID_STATUS);
-                }
+            if (hearingDate.isAfter(today) && !isHearingDayEmpty) {
+                throw new BadRequestException(HEARING_ACTUALS_INVALID_STATUS);
             }
         }
     }

--- a/src/test/java/uk/gov/hmcts/reform/hmc/model/ActualHearingDayTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/hmc/model/ActualHearingDayTest.java
@@ -1,0 +1,42 @@
+package uk.gov.hmcts.reform.hmc.model;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ActualHearingDayTest {
+
+    private ActualHearingDay actualHearingDay;
+
+    @BeforeEach
+    void setUp() {
+        actualHearingDay = new ActualHearingDay();
+    }
+
+    @Test
+    void notRequiredDefaultToFalse() {
+        assertFalse(actualHearingDay.getNotRequired(), "Default notRequired value should be false");
+    }
+
+    @Test
+    void notRequiredFalseWhenValueNull() {
+        actualHearingDay.setNotRequired(null);
+        assertFalse(actualHearingDay.getNotRequired(), "notRequired value should be false when set to null");
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void notRequiredSetWhenValueNotNull(boolean notRequired) {
+        actualHearingDay.setNotRequired(notRequired);
+
+        if (notRequired) {
+            assertTrue(actualHearingDay.getNotRequired(), "notRequired value should be true");
+        } else {
+            assertFalse(actualHearingDay.getNotRequired(), "notRequired value should be false");
+        }
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/hmc/service/HearingActualsServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/hmc/service/HearingActualsServiceTest.java
@@ -339,17 +339,14 @@ class HearingActualsServiceTest {
 
         @Test
         void hearingDate_Today_Outcome_NotEmpty_StartTime_Present_NotRequired_False() {
-            createHearingEntity(VALID_HEARING_STATUS);
+            createActuals();
             HearingActual actual = TestingUtil.hearingActualOutcomeAndActualHearingDaysNull(Boolean.FALSE);
-            actual.getActualHearingDays().get(0).setHearingDate(LocalDate.now());
-            actual.getActualHearingDays().get(0).setHearingStartTime(LocalDate.now()
-                                                                         .plusDays(5).atStartOfDay());
+            actual.getActualHearingDays().getFirst().setHearingDate(LocalDate.now());
+            actual.getActualHearingDays().getFirst().setHearingStartTime(LocalDate.now()
+                                                                             .plusDays(5).atStartOfDay());
             HearingActualsOutcome outcome = actual.getHearingOutcome();
             outcome.setHearingFinalFlag(Boolean.TRUE);
-            Exception exception = assertThrows(BadRequestException.class, () -> {
-                hearingActualsService.updateHearingActuals(HEARING_ID, CLIENT_S2S_TOKEN, actual);
-            });
-            assertEquals(HEARING_ACTUALS_INVALID_STATUS, exception.getMessage());
+            assertDoesNotThrow(() -> hearingActualsService.updateHearingActuals(HEARING_ID, CLIENT_S2S_TOKEN, actual));
         }
 
         @Test

--- a/src/test/java/uk/gov/hmcts/reform/hmc/service/HearingActualsServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/hmc/service/HearingActualsServiceTest.java
@@ -5,9 +5,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.reform.hmc.data.ActualHearingEntity;
 import uk.gov.hmcts.reform.hmc.data.HearingDayDetailsEntity;
@@ -55,7 +53,6 @@ class HearingActualsServiceTest {
     public static final Long HEARING_ID = 2000000000L;
     private static final String CLIENT_S2S_TOKEN = "s2s_token";
 
-    @InjectMocks
     private HearingActualsServiceImpl hearingActualsService;
 
     @Mock
@@ -77,8 +74,7 @@ class HearingActualsServiceTest {
     private HearingStatusAuditService hearingStatusAuditService;
 
     @BeforeEach
-    public void setUp() {
-        MockitoAnnotations.openMocks(this);
+    void setUp() {
         HearingActualsMapper hearingActualsMapper = new HearingActualsMapper();
         HearingIdValidator hearingIdValidator = new HearingIdValidator(hearingRepository,
                 actualHearingRepository, actualHearingDayRepository);
@@ -138,7 +134,7 @@ class HearingActualsServiceTest {
     @DisplayName("putHearingActuals")
     class PutHearingActuals {
         @BeforeEach
-        public void setUp() {
+        void setUp() {
             HearingIdValidator hearingIdValidator = new HearingIdValidator(hearingRepository,
                     actualHearingRepository, actualHearingDayRepository);
             HearingActualsValidator hearingActualsValidator = new HearingActualsValidator(hearingIdValidator);
@@ -168,10 +164,10 @@ class HearingActualsServiceTest {
 
         @Test
         void shouldThrowExceptionWhenInvalidHearingId() {
-            Exception exception = assertThrows(BadRequestException.class, () -> {
-                hearingActualsService.updateHearingActuals(INVALID_HEARING_ID, CLIENT_S2S_TOKEN,
-                                                           TestingUtil.hearingActual());
-            });
+            HearingActual hearingActual = TestingUtil.hearingActual();
+            Exception exception = assertThrows(BadRequestException.class, () ->
+                hearingActualsService.updateHearingActuals(INVALID_HEARING_ID, CLIENT_S2S_TOKEN, hearingActual)
+            );
             assertEquals("Invalid hearing Id", exception.getMessage());
             verify(hearingStatusAuditService, times(0))
                 .saveAuditTriageDetailsWithUpdatedDateOrCurrentDate(any());
@@ -179,9 +175,10 @@ class HearingActualsServiceTest {
 
         @Test
         void shouldThrowExceptionWhenNoHearingIdFound() {
-            Exception exception = assertThrows(HearingNotFoundException.class, () -> {
-                hearingActualsService.updateHearingActuals(HEARING_ID, CLIENT_S2S_TOKEN, TestingUtil.hearingActual());
-            });
+            HearingActual hearingActual = TestingUtil.hearingActual();
+            Exception exception = assertThrows(HearingNotFoundException.class, () ->
+                hearingActualsService.updateHearingActuals(HEARING_ID, CLIENT_S2S_TOKEN, hearingActual)
+            );
             assertEquals("001 No such id: 2000000000", exception.getMessage());
             verify(hearingStatusAuditService, times(0))
                 .saveAuditTriageDetailsWithUpdatedDateOrCurrentDate(any());
@@ -191,9 +188,10 @@ class HearingActualsServiceTest {
         void shouldThrowExceptionWhenHearingStatusNotAllowingActuals() {
             createHearingEntity("HEARING_REQUESTED");
 
-            Exception exception = assertThrows(BadRequestException.class, () -> {
-                hearingActualsService.updateHearingActuals(HEARING_ID, CLIENT_S2S_TOKEN, TestingUtil.hearingActual());
-            });
+            HearingActual hearingActual = TestingUtil.hearingActual();
+            Exception exception = assertThrows(BadRequestException.class, () ->
+                hearingActualsService.updateHearingActuals(HEARING_ID, CLIENT_S2S_TOKEN, hearingActual)
+            );
             assertEquals("002 invalid status HEARING_REQUESTED", exception.getMessage());
         }
 
@@ -203,20 +201,21 @@ class HearingActualsServiceTest {
             given(hearing.getStatus()).willReturn(VALID_HEARING_STATUS);
             given(hearingRepository.findById(HEARING_ID)).willReturn(Optional.of(hearing));
 
-            Exception exception = assertThrows(BadRequestException.class, () -> {
-                hearingActualsService.updateHearingActuals(HEARING_ID, CLIENT_S2S_TOKEN,
-                                                           TestingUtil.hearingActualWithDuplicatedHearingDate());
-            });
+            HearingActual hearingActual = TestingUtil.hearingActualWithDuplicatedHearingDate();
+            Exception exception = assertThrows(BadRequestException.class, () ->
+                hearingActualsService.updateHearingActuals(HEARING_ID, CLIENT_S2S_TOKEN, hearingActual)
+            );
             assertEquals("004 non-unique dates", exception.getMessage());
         }
 
         @Test
         void shouldThrowExceptionWhenOneHearingActualsDayInTheFuture() {
             createHearingEntity(VALID_HEARING_STATUS);
-            Exception exception = assertThrows(BadRequestException.class, () -> {
-                hearingActualsService.updateHearingActuals(HEARING_ID, CLIENT_S2S_TOKEN,
-                                                           TestingUtil.hearingActualWithHearingDateInFuture());
-            });
+
+            HearingActual hearingActual = TestingUtil.hearingActualWithHearingDateInFuture();
+            Exception exception = assertThrows(BadRequestException.class, () ->
+                hearingActualsService.updateHearingActuals(HEARING_ID, CLIENT_S2S_TOKEN, hearingActual)
+            );
             assertEquals(HEARING_ACTUALS_INVALID_STATUS, exception.getMessage());
         }
 
@@ -242,18 +241,18 @@ class HearingActualsServiceTest {
             given(hearing.getHearingResponseForLatestRequest()).willReturn(Optional.of(hearingResponseEntity));
 
             HearingDayDetailsEntity hearingDayDetailsEntity = new HearingDayDetailsEntity();
-            final LocalDateTime earliestHearingDate = LocalDateTime.of(2022, 1, 29, 10,
-                    30, 00);
+            final LocalDateTime earliestHearingDate = LocalDateTime.of(2022, 1, 29, 10, 30, 0);
             hearingDayDetailsEntity.setStartDateTime(earliestHearingDate);
             given(hearingResponseEntity.getEarliestHearingDayDetails()).willReturn(
                     Optional.of(hearingDayDetailsEntity));
 
-            Exception exception = assertThrows(BadRequestException.class, () -> {
-                hearingActualsService.updateHearingActuals(HEARING_ID,CLIENT_S2S_TOKEN, TestingUtil.hearingActual(
-                    hearingActualsOutcome("CANCELLED", null),
-                    List.of(actualHearingDay(LocalDate.of(2022, 2, 28)))
-                ));
-            });
+            HearingActual hearingActual = TestingUtil.hearingActual(
+                hearingActualsOutcome("CANCELLED", null),
+                List.of(actualHearingDay(LocalDate.of(2022, 2, 28)))
+            );
+            Exception exception = assertThrows(BadRequestException.class, () ->
+                hearingActualsService.updateHearingActuals(HEARING_ID,CLIENT_S2S_TOKEN, hearingActual)
+            );
             assertTrue(exception.getMessage().contains("CANCELLED result requires a hearingResultReasonType"));
         }
 
@@ -261,8 +260,7 @@ class HearingActualsServiceTest {
         void shouldThrowExceptionWhenHearingActualDateInFuture() {
             HearingEntity hearing = mock(HearingEntity.class);
             final LocalDate lowestStartDate = LocalDate.of(2022, 1, 31);
-            final LocalDateTime earliestHearingDate = LocalDateTime.of(2022, 2, 25, 10,
-                    30, 00);
+            final LocalDateTime earliestHearingDate = LocalDateTime.of(2022, 2, 25, 10, 30, 0);
             given(hearing.getStatus()).willReturn(VALID_HEARING_STATUS);
             given(hearingRepository.findById(HEARING_ID)).willReturn(Optional.of(hearing));
             HearingResponseEntity hearingResponseEntity = mock(HearingResponseEntity.class);
@@ -396,7 +394,7 @@ class HearingActualsServiceTest {
             given(hearingResponseEntityMock.getEarliestHearingDayDetails()).willReturn(
                 Optional.of(hearingDayDetailsEntity));
             given(hearingResponseEntityMock.getEarliestHearingDayDetails().get().getStartDateTime())
-                .willReturn(LocalDateTime.of(2022, 1, 22, 10,30, 00));
+                .willReturn(LocalDateTime.of(2022, 1, 22, 10, 30, 0));
 
             ActualHearingEntity actualHearingMock = mock(ActualHearingEntity.class);
             given(actualHearingRepository.save(any())).willReturn(actualHearingMock);

--- a/src/test/java/uk/gov/hmcts/reform/hmc/validator/HearingActualsValidatorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/hmc/validator/HearingActualsValidatorTest.java
@@ -2,6 +2,9 @@ package uk.gov.hmcts.reform.hmc.validator;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
@@ -13,8 +16,8 @@ import uk.gov.hmcts.reform.hmc.data.LinkedGroupDetails;
 import uk.gov.hmcts.reform.hmc.domain.model.enums.PutHearingStatus;
 import uk.gov.hmcts.reform.hmc.exceptions.BadRequestException;
 import uk.gov.hmcts.reform.hmc.exceptions.ValidationError;
+import uk.gov.hmcts.reform.hmc.model.ActualHearingDay;
 import uk.gov.hmcts.reform.hmc.model.HearingActual;
-import uk.gov.hmcts.reform.hmc.model.HearingActualsOutcome;
 import uk.gov.hmcts.reform.hmc.model.HearingResultType;
 import uk.gov.hmcts.reform.hmc.repository.ActualHearingRepository;
 import uk.gov.hmcts.reform.hmc.repository.HearingRepository;
@@ -22,13 +25,17 @@ import uk.gov.hmcts.reform.hmc.utils.TestingUtil;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.reform.hmc.exceptions.ValidationError.HA_OUTCOME_FINAL_FLAG_NOT_EMPTY;
@@ -210,44 +217,6 @@ class HearingActualsValidatorTest {
     }
 
     @Test
-    void hearingActualWithOutcomeNull() {
-        HearingActual actual = TestingUtil.hearingActualWithOutcomeNull();
-        assertDoesNotThrow(() -> {
-            hearingActualsValidator.validateHearingActualDaysNotInTheFuture(actual);
-        });
-    }
-
-    @Test
-    void hearingDate_Future_Outcome_NotEmpty_StartTime_Present_NotRequired_True() {
-        HearingActual actual = TestingUtil.hearingActualWithOutcomeNull();
-        HearingActualsOutcome outcome = TestingUtil.hearingActualsOutcome();
-        actual.setHearingOutcome(outcome);
-        assertDoesNotThrow(() -> {
-            hearingActualsValidator.validateHearingActualDaysNotInTheFuture(actual);
-        });
-    }
-
-    @Test
-    void hearingDate_Future_Outcome_Empty_NotRequired_False() {
-        HearingActual actual = TestingUtil.hearingActualOutcomeAndActualHearingDaysNull(Boolean.FALSE);
-        assertDoesNotThrow(() -> {
-            hearingActualsValidator.validateHearingActualDaysNotInTheFuture(actual);
-        });
-    }
-
-    @Test
-    void hearingDate_Today_Outcome_NotEmpty_NotRequired_False() {
-        HearingActual actual = TestingUtil.hearingActualWithOutcomeNull();
-        actual.getActualHearingDays().get(0).setHearingDate(LocalDate.now());
-        actual.getActualHearingDays().get(0).setNotRequired(Boolean.FALSE);
-        HearingActualsOutcome outcome = TestingUtil.hearingActualsOutcome();
-        actual.setHearingOutcome(outcome);
-        assertDoesNotThrow(() -> {
-            hearingActualsValidator.validateHearingActualDaysNotInTheFuture(actual);
-        });
-    }
-
-    @Test
     void hearingDate_Future_Outcome_Empty_NotRequired_Default() {
         HearingActual actual = TestingUtil.hearingActualOutcomeAndActualHearingDaysNull();
         assertDoesNotThrow(() -> {
@@ -256,24 +225,113 @@ class HearingActualsValidatorTest {
     }
 
     @Test
-    void hearingDate_Today_StartTime_Present_NotRequired_False() {
-        HearingActual actual = TestingUtil.hearingActualOutcomeAndActualHearingDaysNull(Boolean.FALSE);
-        actual.getActualHearingDays().get(0).setHearingDate(LocalDate.now());
-        actual.getActualHearingDays().get(0).setHearingStartTime(LocalDate.now().plusDays(5).atStartOfDay());
-        Exception exception = assertThrows(BadRequestException.class, () -> {
-            hearingActualsValidator.validateHearingActualDaysNotInTheFuture(actual);
-        });
-        assertTrue(exception.getMessage().contains(HEARING_ACTUALS_INVALID_STATUS));
+    void validateHearingActualDaysNotInTheFuture_NotRequiredShouldBeFalseWhenSetToNull() {
+        LocalDate futureDate = LocalDate.now().plusDays(1);
+        LocalDateTime futureStartTime = LocalDateTime.of(futureDate, LocalTime.of(13, 0, 0));
+        LocalDateTime futureEndTime = LocalDateTime.of(futureDate, LocalTime.of(14, 0, 0));
+
+        ActualHearingDay actualHearingDay = createActualHearingDay(futureDate, null, futureStartTime, futureEndTime);
+        HearingActual hearingActual = new HearingActual();
+        hearingActual.setActualHearingDays(List.of(actualHearingDay));
+
+        BadRequestException exception =
+            assertThrows(BadRequestException.class,
+                         () -> hearingActualsValidator.validateHearingActualDaysNotInTheFuture(hearingActual),
+                         "BadRequestException should be thrown");
+
+        assertEquals(HEARING_ACTUALS_INVALID_STATUS,
+                     exception.getMessage(),
+                     "BadRequestException has unexpected message");
     }
 
-    @Test
-    void hearingDate_Future_StartTime_Present_NotRequired_True() {
-        HearingActual actual = TestingUtil.hearingActualOutcomeAndActualHearingDaysNull(Boolean.TRUE);
-        actual.getActualHearingDays().get(0).setHearingStartTime(LocalDate.now().plusDays(5).atStartOfDay());
-        Exception exception = assertThrows(BadRequestException.class, () -> {
-            hearingActualsValidator.validateHearingActualDaysNotInTheFuture(actual);
-        });
-        assertTrue(exception.getMessage().contains(HEARING_ACTUALS_INVALID_STATUS));
+    @ParameterizedTest
+    @MethodSource("actualHearingDayAccepted")
+    void validateHearingActualDaysNotInTheFuture_ShouldAcceptActualHearingDay(ActualHearingDay actualHearingDay) {
+        HearingActual hearingActual = new HearingActual();
+        hearingActual.setActualHearingDays(List.of(actualHearingDay));
+
+        assertDoesNotThrow(() -> hearingActualsValidator.validateHearingActualDaysNotInTheFuture(hearingActual),
+                           "Exception should not be thrown");
+    }
+
+    @ParameterizedTest
+    @MethodSource("actualHearingDayRejected")
+    void validateHearingActualDaysNotInTheFuture_ShouldRejectActualHearingDay(ActualHearingDay actualHearingDay) {
+        HearingActual hearingActual = new HearingActual();
+        hearingActual.setActualHearingDays(List.of(actualHearingDay));
+
+        BadRequestException exception =
+            assertThrows(BadRequestException.class,
+                         () -> hearingActualsValidator.validateHearingActualDaysNotInTheFuture(hearingActual),
+                         "BadRequestException should be thrown");
+
+        assertEquals(HEARING_ACTUALS_INVALID_STATUS,
+                     exception.getMessage(),
+                     "BadRequestException has unexpected message");
+    }
+
+    private static Stream<Arguments> actualHearingDayAccepted() {
+        LocalDate currentDate = LocalDate.now();
+        LocalDateTime currentStartTime = LocalDateTime.of(currentDate, LocalTime.of(13, 0, 0));
+        LocalDateTime currentEndTime = LocalDateTime.of(currentDate, LocalTime.of(14, 0, 0));
+
+        ActualHearingDay dayCurrentRequiredEmpty = createActualHearingDay(currentDate, false);
+        ActualHearingDay dayCurrentRequiredNotEmpty =
+            createActualHearingDay(currentDate, false, currentStartTime, currentEndTime);
+
+        ActualHearingDay dayCurrentNotRequiredEmpty = createActualHearingDay(currentDate, true);
+        ActualHearingDay dayCurrentNotRequiredNotEmpty =
+            createActualHearingDay(currentDate, true, currentStartTime, currentEndTime);
+
+        LocalDate futureDate = LocalDate.now().plusDays(1);
+
+        ActualHearingDay dayFutureRequiredEmpty = createActualHearingDay(futureDate, false);
+        ActualHearingDay dayFutureNotRequiredEmpty = createActualHearingDay(futureDate, true);
+
+        return Stream.of(
+            arguments(dayCurrentRequiredEmpty),
+            arguments(dayCurrentRequiredNotEmpty),
+            arguments(dayCurrentNotRequiredEmpty),
+            arguments(dayCurrentNotRequiredNotEmpty),
+            arguments(dayFutureRequiredEmpty),
+            arguments(dayFutureNotRequiredEmpty)
+        );
+    }
+
+    private static Stream<Arguments> actualHearingDayRejected() {
+        LocalDate futureDate = LocalDate.now().plusDays(1);
+        LocalDateTime futureStartTime = LocalDateTime.of(futureDate, LocalTime.of(13, 0, 0));
+        LocalDateTime futureEndTime = LocalDateTime.of(futureDate, LocalTime.of(14, 0, 0));
+
+        ActualHearingDay dayFutureRequiredNotEmpty =
+            createActualHearingDay(futureDate, false, futureStartTime, futureEndTime);
+
+        ActualHearingDay dayFutureNotRequiredNotEmpty =
+            createActualHearingDay(futureDate, true, futureStartTime, futureEndTime);
+
+        return Stream.of(
+            arguments(dayFutureRequiredNotEmpty),
+            arguments(dayFutureNotRequiredNotEmpty)
+        );
+    }
+
+    private static ActualHearingDay createActualHearingDay(LocalDate hearingDate, Boolean notRequired) {
+        ActualHearingDay actualHearingDay = new ActualHearingDay();
+        actualHearingDay.setHearingDate(hearingDate);
+        actualHearingDay.setNotRequired(notRequired);
+
+        return actualHearingDay;
+    }
+
+    private static ActualHearingDay createActualHearingDay(LocalDate hearingDate,
+                                                           Boolean notRequired,
+                                                           LocalDateTime hearingStartTime,
+                                                           LocalDateTime hearingEndTime) {
+        ActualHearingDay actualHearingDay = createActualHearingDay(hearingDate, notRequired);
+        actualHearingDay.setHearingStartTime(hearingStartTime);
+        actualHearingDay.setHearingEndTime(hearingEndTime);
+
+        return actualHearingDay;
     }
 
     protected void generateHearingResponseEntity(Integer requestVersion, HearingEntity hearingEntity,
@@ -329,5 +387,4 @@ class HearingActualsValidatorTest {
         request.setHearingRequestReceivedDateTime(receivedDateTime);
         return request;
     }
-
 }

--- a/src/test/java/uk/gov/hmcts/reform/hmc/validator/HearingActualsValidatorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/hmc/validator/HearingActualsValidatorTest.java
@@ -60,7 +60,7 @@ class HearingActualsValidatorTest {
     private static final Long VALID_HEARING_ID = 2000000000L;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         MockitoAnnotations.openMocks(this);
         hearingActualsValidator = new HearingActualsValidator(hearingIdValidator);
     }


### PR DESCRIPTION
### JIRA link (if applicable) ###
[HMAN-1131](https://tools.hmcts.net/jira/browse/HMAN-1131)


### Change description ###
Amended ActualHearingDay to replace generated setter method for 'not required' field with a custom one.  Custom setter sets the value of not required field to false if a null Boolean object is passed to it.

Added unit test class for ActualHearingDay.

Changed logic in HearingActualsValidator validateHearingActualDaysNotInTheFuture() method to only reject hearing days in the future that are not empty.  This should cover the HMAN-1075 requirement and keep validation of actual hearing days for today as they were prior to the HMAN-1075 changes.

Reworked validateHearingActualDaysNotInTheFuture() method tests in HearingActualsValidatorTest to cover changed logic.  Combined a number of tests into parameterised tests.

Changed hearingDate_Today_Outcome_NotEmpty_StartTime_Present_NotRequired_False() test in HearingActualsServiceTest in line with changed validateHearingActualDaysNotInTheFuture() logic.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
