### PR TITLE
HMAN-1154: Resolve CVEs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -231,6 +231,7 @@ ext {
   set('log4j2.version', '2.25.5')
   set('commons-lang3.version', '3.18.0')
   set('tomcat.version', '10.1.57')
+  set('httpcore5.version', '5.4.3')
 
   junit                 = '5.13.4'
   junitPlatform         = '1.13.4'

--- a/build.gradle
+++ b/build.gradle
@@ -226,10 +226,11 @@ sonarqube {
 ext {
   set('springCloudVersion', '2025.0.0')
   set('snakeyaml.version', '2.3')
-  set('jackson.version', '2.18.8')
+  set('jackson.version', '2.18.9')
   set('diuspactproviderVersion', '4.1.43')
-  set('log4j2.version', '2.25.4')
+  set('log4j2.version', '2.25.5')
   set('commons-lang3.version', '3.18.0')
+  set('tomcat.version', '10.1.57')
 
   junit                 = '5.13.4'
   junitPlatform         = '1.13.4'
@@ -382,7 +383,7 @@ dependencies {
   annotationProcessor group: 'org.projectlombok', name: 'lombok-mapstruct-binding', version: '0.2.0'
   annotationProcessor group: 'org.mapstruct', name: 'mapstruct-processor', version: mapstruct
   compileOnly group: 'org.jetbrains.kotlin', name: 'kotlin-stdlib', version: '2.2.10'
-  runtimeOnly group: 'org.postgresql', name: 'postgresql', version: '42.7.11'
+  runtimeOnly group: 'org.postgresql', name: 'postgresql', version: '42.7.12'
 
 
   testImplementation libraries.junit5

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -1,80 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
   <suppress>
-    <notes>
-      CVE-2026-33117 - False positive, see https://github.com/dependency-check/DependencyCheck/issues/8553
-      CVE-2026-42582 - Only applies to Netty 4.2.x, see https://github.com/netty/netty/security/advisories/GHSA-2c5c-chwr-9hqw
-    </notes>
-    <cve>CVE-2026-33117</cve>
-    <cve>CVE-2026-42582</cve>
+    <notes><![CDATA[
+    The Azure Key Vault Keys advisory does not apply to these Azure Service Bus runtime artifacts,
+    but dependency-check incorrectly matches the shared Azure SDK CPE against them.
+    See https://github.com/dependency-check/DependencyCheck/issues/8553
+    ]]></notes>
+    <packageUrl regex="true">^pkg:maven/com\.azure/(azure-core@1\.58\.0|azure-core-amqp@2\.11\.4|azure-core-http-netty@1\.16\.4|azure-json@1\.5\.1)$</packageUrl>
+    <cpe regex="true">^cpe:/a:microsoft:azure_sdk_for_java.*$</cpe>
   </suppress>
   <suppress>
     <notes><![CDATA[
-    file name: angus-activation-2.0.3.jar
+    The cve.org records for these CVEs indicate that they only apply to httpcore 5.x, but the NVD records state
+    that they apply to all versions up to and including 5.4.2.
+    Discussion at https://github.com/dependency-check/DependencyCheck/issues/8653 suggests NVD need to update their
+    records to exclude versions before 5.x, but there is a suggestion that it could also affect 4.4.16.
+    Apache httpcore 4 is EOL (https://hc.apache.org/httpcomponents-core-4.4.x/index.html) so there may not be any
+    more releases of it.
     ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.eclipse\.angus/angus-activation@.*$</packageUrl>
-    <cve>CVE-2025-7962</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-    file name: jackson-databind-2.18.8.jar
-    ]]></notes>
-    <packageUrl regex="true">^pkg:maven/com\.fasterxml\.jackson\.core/jackson-databind@.*$</packageUrl>
-    <cve>CVE-2026-54515</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-    file name: log4j-api-2.25.4.jar
-    ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.apache\.logging\.log4j/log4j-api@.*$</packageUrl>
-    <cve>CVE-2026-49844</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-    file name: log4j-to-slf4j-2.25.4.jar
-    ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.apache\.logging\.log4j/log4j-to-slf4j@.*$</packageUrl>
-    <cve>CVE-2026-49844</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-    file name: tomcat-embed-core-10.1.55.jar
-    ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.apache\.tomcat\.embed/tomcat-embed-core@.*$</packageUrl>
-    <cve>CVE-2026-50229</cve>
-    <cve>CVE-2026-53404</cve>
-    <cve>CVE-2026-53434</cve>
-    <cve>CVE-2026-55276</cve>
-    <cve>CVE-2026-55955</cve>
-    <cve>CVE-2026-55956</cve>
-    <cve>CVE-2026-59083</cve>
-    <cve>CVE-2026-59084</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-    file name: tomcat-embed-websocket-10.1.55.jar
-    ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.apache\.tomcat\.embed/tomcat-embed-websocket@.*$</packageUrl>
-    <cve>CVE-2026-50229</cve>
-    <cve>CVE-2026-53404</cve>
-    <cve>CVE-2026-53434</cve>
-    <cve>CVE-2026-55276</cve>
-    <cve>CVE-2026-55955</cve>
-    <cve>CVE-2026-55956</cve>
-    <cve>CVE-2026-59083</cve>
-    <cve>CVE-2026-59084</cve>
-  </suppress>
-  <suppress>
+    <packageUrl regex="true">^pkg:maven/org\.apache\.httpcomponents/httpcore@4\.4\.16$</packageUrl>
     <cve>CVE-2026-54399</cve>
-  </suppress>
-  <suppress>
     <cve>CVE-2026-54428</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-    file name: postgresql-42.7.11.jar
-    ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.postgresql/postgresql@.*$</packageUrl>
-    <cve>CVE-2026-54291</cve>
   </suppress>
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###
[HMAN-1154](https://tools.hmcts.net/jira/browse/HMAN-1154)


### Change description ###
Updated jackson.version property to 2.18.9. Unable to use 2.21.x provided by Spring Boot due to limitation caused by befta-fw.

Updated log4j2.version property to 2.25.5.

Added tomcat.version property and set value to 10.1.57

Updated org.postgres:postgresql version to 42.7.12


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
